### PR TITLE
Fixed an issue regarding New Years 2011/2022 observance date

### DIFF
--- a/holidays.gemspec
+++ b/holidays.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{holidays}
-  s.version = "1.0.0"
+  s.version = "1.0.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Alex Dunae", "Rowan Crawford"]


### PR DESCRIPTION
In version 1.0.0, if the date range includes 12/31/2010, but not 1/1/2011, no holidays will be found with the observed option set. I added the following checks:
if the start_date if on the first day of the month add the previous month's holidays
if the end_date is on the last day of the month add the next month's holidays
