### PR TITLE
Expose regions

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -298,6 +298,11 @@ module Holidays
     paths = Dir.glob(DEFINITION_PATH + '/*.rb')
     full_path ? paths : paths.collect { |path| path.match(/([a-z_-]+)\.rb/i)[1].to_sym }
   end
+
+  # Returns an array of symbols of all the available holiday regions.
+  def self.regions
+    @@regions
+  end
   
   # Load all available holiday definitions
   def self.load_all

--- a/test/test_all_regions.rb
+++ b/test/test_all_regions.rb
@@ -40,6 +40,16 @@ class MultipleRegionsTests < Test::Unit::TestCase
     assert holidays.any? { |h| h[:name] == 'Dia do Trabalho' } # :br
     assert holidays.any? { |h| h[:name] == 'Vappu' }           # :fi
   end
+
+  def test_getting_regions
+    Holidays.load_all
+    regions = Holidays.regions
+
+    assert regions.size > 30
+
+    assert regions.include? :nyse
+    assert regions.include? :united_nations
+  end
   
 private
   def def_count


### PR DESCRIPTION
Good day!

I was looking for a way to validate user supplied holiday regions against what was available in the `Holidays` class and, as such, needed a simple way to access the `@@regions` class variable (i.e rather than resorting to `Holidays.send(:instance_variable_get, :@@regions)`).  Please let me know if you would like me to make any additional changes to get this pull request accepted; I would really like to see it in upstream.

Thanks!
