### PR TITLE
Fix Boxing Day substitute day

### DIFF
--- a/data/gb.yaml
+++ b/data/gb.yaml
@@ -99,6 +99,7 @@ tests: |
     assert_equal 'Boxing Day', Date.civil(2008,12,26).holidays(:gb_, :observed)[0][:name]
     assert_equal 'Boxing Day', Date.civil(2009,12,28).holidays(:gb_, :observed)[0][:name]
     assert_equal 'Boxing Day', Date.civil(2010,12,28).holidays(:gb_, :observed)[0][:name]
+    assert_equal 'Boxing Day', Date.civil(2011,12,27).holidays(:gb_, :observed)[0][:name]
 
     [:gb_wls, :gb_eng, :gb_nir, :gb_eaw, :gb_].each do |r|
       assert_equal 'Easter Monday', Date.civil(2008,3,24).holidays(r)[0][:name]

--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -278,7 +278,11 @@ module Holidays
   # Move Boxing Day if it falls on a weekend, leaving room for Christmas.
   # Used as a callback function.
   def self.to_weekday_if_boxing_weekend(date)
-    date += 2 if date.wday == 6 or date.wday == 0
+    if date.wday == 6 or date.wday == 0
+      date += 2
+    elsif date.wday == 1
+      date += 1
+    end
     date
   end
 

--- a/test/defs/test_defs_europe.rb
+++ b/test/defs/test_defs_europe.rb
@@ -227,6 +227,7 @@ assert_equal 'Christmas Day', Date.civil(2010,12,27).holidays(:gb_, :observed)[0
 assert_equal 'Boxing Day', Date.civil(2008,12,26).holidays(:gb_, :observed)[0][:name]
 assert_equal 'Boxing Day', Date.civil(2009,12,28).holidays(:gb_, :observed)[0][:name]
 assert_equal 'Boxing Day', Date.civil(2010,12,28).holidays(:gb_, :observed)[0][:name]
+assert_equal 'Boxing Day', Date.civil(2011,12,27).holidays(:gb_, :observed)[0][:name]
 
 [:gb_wls, :gb_eng, :gb_nir, :gb_eaw, :gb_].each do |r|
   assert_equal 'Easter Monday', Date.civil(2008,3,24).holidays(r)[0][:name]

--- a/test/defs/test_defs_gb.rb
+++ b/test/defs/test_defs_gb.rb
@@ -27,6 +27,7 @@ assert_equal 'Christmas Day', Date.civil(2010,12,27).holidays(:gb_, :observed)[0
 assert_equal 'Boxing Day', Date.civil(2008,12,26).holidays(:gb_, :observed)[0][:name]
 assert_equal 'Boxing Day', Date.civil(2009,12,28).holidays(:gb_, :observed)[0][:name]
 assert_equal 'Boxing Day', Date.civil(2010,12,28).holidays(:gb_, :observed)[0][:name]
+assert_equal 'Boxing Day', Date.civil(2011,12,27).holidays(:gb_, :observed)[0][:name]
 
 [:gb_wls, :gb_eng, :gb_nir, :gb_eaw, :gb_].each do |r|
   assert_equal 'Easter Monday', Date.civil(2008,3,24).holidays(r)[0][:name]


### PR DESCRIPTION
From [Wikipedia](http://en.wikipedia.org/wiki/Boxing_Day):

> In the UK, Boxing Day is a bank holiday. If Boxing Day falls on a Saturday, the following Monday is given as a substitute bank holiday. On the occasion when Christmas Day is on a Saturday – with Boxing Day on the Sunday – the following Monday (27) and Tuesday (28) of December both become bank holidays.

I believe the same rule also applies to New Zealand, South Africa and Australia.

Note: Originally this PR was only for GB, hence the branch name, but I later realised other countries were also incorrect.

**References**

UK: http://projectbritain.com/bankholidays.html
NZ: http://www.dol.govt.nz/er/holidaysandleave/publicholidays/publicholidaydates/past-dates.asp
SA: http://www.kwathabeng.co.za/travel/south-africa/destinations.html?cal=south-african-public-holidays&year=2011
AU: https://www.fairwork.gov.au/leave/public-holidays/pages/listof2011publicholidays.aspx
