### PR TITLE
Remove 'Pâques' and 'Pentecôte' sundays from :fr data

### DIFF
--- a/data/fr.yaml
+++ b/data/fr.yaml
@@ -10,6 +10,7 @@ months:
   - name: Pâques
     regions: [fr]
     function: easter(year)
+    type: informal
   - name: Lundi de Pâques
     regions: [fr]
     function: easter(year)+1
@@ -19,6 +20,7 @@ months:
   - name: Pentecôte
     regions: [fr]
     function: easter(year)+49
+    type: informal
   - name: Lundi de Pentecôte
     regions: [fr]
     function: easter(year)+50


### PR DESCRIPTION
These 2 sundays are not holidays in french law:

http://www.service-public.fr/actualites/00790.html
