### PR TITLE
[FR] Update Christmas name in french that was wrong from 'Nöel' to 'Noël'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -71,7 +71,7 @@ To make changes to any of the definitions, edit the YAML files only.
 
 Tests are also added at the end of the YAML files. Please add tests, it makes the pull requests go around.
 
-After you're satisfied with the YAML file, edit the index.yaml file, run rake defs:build_all and rake defs:manifest, which will generate the ruby files that make up the actual code as well as the tests.
+After you're satisfied with the YAML file, edit the index.yaml file, using ruby > 1.9.2 run rake defs:build_all and rake defs:manifest, which will generate the ruby files that make up the actual code as well as the tests.
 
 It is also very appreciated if documentation is attached to the pull request, a simple wikipedia post referencing the change would suffice.
 

--- a/data/fr.yaml
+++ b/data/fr.yaml
@@ -1,9 +1,9 @@
 # French holiday definitions for the Ruby Holiday gem.
 #
-# Updated: 2008-11-2*.
+# Updated: 2013-10-2*.
 # Sources:
-# - http://en.wikipedia.org/wiki/Holidays_in_France
-# - http://riviera.angloinfo.com/information/1/pub_hols.asp
+# - http://fr.wikipedia.org/wiki/Jours_f%C3%A9ri%C3%A9s_en_France#Les_f.C3.AAtes_f.C3.A9ri.C3.A9es
+# - http://vosdroits.service-public.fr/particuliers/F2405.xhtml
 --- 
 months:
   0: 
@@ -49,7 +49,7 @@ months:
     regions: [fr]
     mday: 11
   12:
-  - name: Nöel
+  - name: Noël
     regions: [fr]
     mday: 25
 tests: |
@@ -65,6 +65,6 @@ tests: |
      Date.civil(2007,8,15) => 'Assomption',
      Date.civil(2007,11,1) => 'Toussaint',
      Date.civil(2007,11,11) => 'Armistice 1918',
-     Date.civil(2007,12,25) => 'Nöel'}.each do |date, name|
+     Date.civil(2007,12,25) => 'Noël'}.each do |date, name|
       assert_equal name, (Holidays.on(date, :fr, :informal)[0] || {})[:name]
     end

--- a/lib/holidays/europe.rb
+++ b/lib/holidays/europe.rb
@@ -221,7 +221,7 @@ module Holidays
             {:mday => 8, :name => "Inmaculada Concepción", :regions => [:es]},
             {:mday => 25, :name => "Navidad del Señor", :regions => [:es]},
             {:mday => 26, :name => "San Esteban", :regions => [:es_ib, :es_ct]},
-            {:mday => 25, :name => "Nöel", :regions => [:fr]},
+            {:mday => 25, :name => "Noël", :regions => [:fr]},
             {:mday => 25, :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :name => "Christmas Day", :regions => [:gb, :ie]},
             {:mday => 26, :observed => lambda { |date| Holidays.to_weekday_if_boxing_weekend(date) }, :observed_id => "to_weekday_if_boxing_weekend", :name => "Boxing Day", :regions => [:gb]},
             {:mday => 25, :name => "Božić", :regions => [:hr]},

--- a/lib/holidays/fr.rb
+++ b/lib/holidays/fr.rb
@@ -30,7 +30,7 @@ module Holidays
       8 => [{:mday => 15, :name => "Assomption", :regions => [:fr]}],
       11 => [{:mday => 1, :name => "Toussaint", :regions => [:fr]},
             {:mday => 11, :name => "Armistice 1918", :regions => [:fr]}],
-      12 => [{:mday => 25, :name => "Nöel", :regions => [:fr]}]
+      12 => [{:mday => 25, :name => "Noël", :regions => [:fr]}]
       }
     end
   end

--- a/test/defs/test_defs_europe.rb
+++ b/test/defs/test_defs_europe.rb
@@ -203,7 +203,7 @@ assert_equal 'Fiesta Nacional de Cataluña', Date.civil(2009,9,11).holidays(:es_
  Date.civil(2007,8,15) => 'Assomption',
  Date.civil(2007,11,1) => 'Toussaint',
  Date.civil(2007,11,11) => 'Armistice 1918',
- Date.civil(2007,12,25) => 'Nöel'}.each do |date, name|
+ Date.civil(2007,12,25) => 'Noël'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :fr, :informal)[0] || {})[:name]
 end
 

--- a/test/defs/test_defs_fr.rb
+++ b/test/defs/test_defs_fr.rb
@@ -19,7 +19,7 @@ class FrDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2007,8,15) => 'Assomption',
  Date.civil(2007,11,1) => 'Toussaint',
  Date.civil(2007,11,11) => 'Armistice 1918',
- Date.civil(2007,12,25) => 'Nöel'}.each do |date, name|
+ Date.civil(2007,12,25) => 'Noël'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :fr, :informal)[0] || {})[:name]
 end
   end


### PR DESCRIPTION
Hello!

Thanks for this very nice gem!

Our team noticed that the name for Christmas holiday was badly translated in French.
So here is a fix to have the correct name (corrected 'Nöel' to 'Noël')

I also specified the ruby version to use to build the ruby files in the README. Coz it messes everything up with ruby-1.8.7.

Have a great day.
Paul
