### PR TITLE
Fixing a small typo in br.yaml file.

### DIFF
--- a/data/br.yaml
+++ b/data/br.yaml
@@ -18,7 +18,7 @@ months:
   - name: Páscoa
     regions: [br]
     function: easter(year)
-  - name: Corpus Christ
+  - name: Corpus Christi
     regions: [br]
     function: easter(year)+60
   1: 


### PR DESCRIPTION
As we can see in the following links:
http://pt.wikipedia.org/wiki/Feriados_no_Brasil
http://pt.wikipedia.org/wiki/Corpus_Christi
