### PR TITLE
bugfix: when no regions are loaded, loading of a region with subregions fails e.g. loading :de_bb fails

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -351,13 +351,21 @@ private
     regions.flatten!
 
     require "holidays/north_america" if regions.include?(:us) # special case for north_america/US cross-linking
-
     regions.each do |r|
       unless r == :any or @@regions.include?(r)
         begin
           require "holidays/#{r.to_s}"
         rescue LoadError => e
-          raise UnknownRegionError, "Could not load holidays/#{r}"
+          # try loading the prefix instead e.g. :de_bb cannot be loaded, try :de
+          if match = /(\w+)_.+$/.match(r)
+            begin
+              require "holidays/#{match[1]}"
+            rescue LoadError => e
+              raise UnknownRegionError, "Could not load holidays/#{r} nor holidays/#{match[1]}"
+            end
+          else
+            raise UnknownRegionError, "Could not load holidays/#{r}"
+          end
         end
       end
     end

--- a/test/test_all_regions.rb
+++ b/test/test_all_regions.rb
@@ -50,6 +50,13 @@ class MultipleRegionsTests < Test::Unit::TestCase
     assert regions.include? :nyse
     assert regions.include? :united_nations
   end
+
+  def test_load_subregion
+    Holidays.send(:remove_const, :DE) #unload de module so that is has to be loaded again
+    Holidays.class_variable_set :@@regions, [] # reset regions
+    holidays = Holidays.on(Date.civil(2014, 1, 1), :de_bb)
+    assert holidays.any? { |h| h[:name] == 'Neujahrstag' }
+  end
   
 private
   def def_count


### PR DESCRIPTION
The following bug occurs if the first region you want to load is a region with subregion, e.g. :de_bb

```
irb(main):001:0> require "holidays"
=> true
irb(main):002:0> Date.today.holiday? :de_bb
Holidays::UnknownRegionError: Could not load holidays/de_bb
irb(main):003:0> Date.today.holiday? :de
=> false
irb(main):004:0> Date.today.holiday? :de_bb
=> false
```

Unfortunately there are regions in lib/holidays with "_" in their name. This is bad because this symbol is also used to specifiy subregions. Therefore i had to nest two rescue blocks in my commit and try to load the prefix. 

Ps: This does not raise an error if you require :de_bbd (which does not exist) but that is another issue which already existed in the previous version.
