### PR TITLE
Add G20 day (Brisbane) and show day (Cairns)

### DIFF
--- a/data/au.yaml
+++ b/data/au.yaml
@@ -110,9 +110,10 @@ months:
   - name: G20 Day
     regions: [au_qld_brisbane]
     function: g20_day_2014_only(year)
-  - name: Recreation Day
+  - name: Recreation Day # http://www.timeanddate.com/holidays/australia/recreation-day
     regions: [au_tas_north]
-    mday: 3
+    wday: 1
+    week: 1
   - name: Melbourne Cup Day
     regions: [au_vic]
     week: 1
@@ -212,6 +213,11 @@ tests: |
     assert_equal 'Royal Hobart Show', Date.civil(2014, 10, 23).holidays(:au_tas_south)[0][:name]
     assert_equal 'Royal Hobart Show', Date.civil(2015, 10, 22).holidays(:au_tas_south)[0][:name]
     assert_equal 'Royal Hobart Show', Date.civil(2016, 10, 20).holidays(:au_tas_south)[0][:name]
+
+    assert_equal 'Recreation Day', Date.civil(2013, 11, 4).holidays(:au_tas_north)[0][:name]
+    assert_equal 'Recreation Day', Date.civil(2014, 11, 3).holidays(:au_tas_north)[0][:name]
+    assert_equal 'Recreation Day', Date.civil(2015, 11, 2).holidays(:au_tas_north)[0][:name]
+    assert_equal 'Recreation Day', Date.civil(2016, 11, 7).holidays(:au_tas_north)[0][:name]
 
     assert_equal 'G20 Day', Date.civil(2014,11,14).holidays(:au_qld_brisbane)[0][:name]
     assert_equal [], Date.civil(2014,11,14).holidays(:au_qld)

--- a/lib/holidays/au.rb
+++ b/lib/holidays/au.rb
@@ -43,7 +43,7 @@ module Holidays
             {:function => lambda { |year| Holidays.qld_queens_bday_october(year) }, :function_id => "qld_queens_bday_october(year)", :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :name => "Queen's Birthday", :regions => [:au_qld]},
             {:function => lambda { |year| Holidays.hobart_show_day(year) }, :function_id => "hobart_show_day(year)", :name => "Royal Hobart Show", :regions => [:au_tas_south]}],
       11 => [{:function => lambda { |year| Holidays.g20_day_2014_only(year) }, :function_id => "g20_day_2014_only(year)", :name => "G20 Day", :regions => [:au_qld_brisbane]},
-            {:mday => 3, :name => "Recreation Day", :regions => [:au_tas_north]},
+            {:wday => 1, :week => 1, :name => "Recreation Day", :regions => [:au_tas_north]},
             {:wday => 2, :week => 1, :name => "Melbourne Cup Day", :regions => [:au_vic]}],
       12 => [{:mday => 25, :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :name => "Christmas Day", :regions => [:au]},
             {:mday => 26, :observed => lambda { |date| Holidays.to_weekday_if_boxing_weekend(date) }, :observed_id => "to_weekday_if_boxing_weekend", :name => "Boxing Day", :regions => [:au]}]

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -61,6 +61,11 @@ assert_equal 'Royal Hobart Show', Date.civil(2014, 10, 23).holidays(:au_tas_sout
 assert_equal 'Royal Hobart Show', Date.civil(2015, 10, 22).holidays(:au_tas_south)[0][:name]
 assert_equal 'Royal Hobart Show', Date.civil(2016, 10, 20).holidays(:au_tas_south)[0][:name]
 
+assert_equal 'Recreation Day', Date.civil(2013, 11, 4).holidays(:au_tas_north)[0][:name]
+assert_equal 'Recreation Day', Date.civil(2014, 11, 3).holidays(:au_tas_north)[0][:name]
+assert_equal 'Recreation Day', Date.civil(2015, 11, 2).holidays(:au_tas_north)[0][:name]
+assert_equal 'Recreation Day', Date.civil(2016, 11, 7).holidays(:au_tas_north)[0][:name]
+
 assert_equal 'G20 Day', Date.civil(2014,11,14).holidays(:au_qld_brisbane)[0][:name]
 assert_equal [], Date.civil(2014,11,14).holidays(:au_qld)
 assert_equal [], Date.civil(2015,11,14).holidays(:au_qld_brisbane)


### PR DESCRIPTION
See http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates for G20, and http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/2014-show-holidays for Cairns.

I'm working on a data mining project at the moment, to add all the regional Australian holidays. Expect more pull requests soon :)
