### PR TITLE
Amend Scottish holidays

### DIFF
--- a/data/gb.yaml
+++ b/data/gb.yaml
@@ -71,6 +71,11 @@ months:
     regions: [gb]
     mday: 5
     type: informal
+  - name: St. Andrew's Day
+    regions: [gb_sct]
+    mday: 30
+    type: informal
+    observed: to_monday_if_weekend
   12:
   - name: Christmas Day
     regions: [gb]
@@ -92,6 +97,7 @@ tests: |
     end
 
     assert_equal 'St. Patrick\'s Day', Date.civil(2008,3,17).holidays(:gb_nir, :informal)[0][:name]
+    assert_equal 'St. Andrew\'s Day', Date.civil(2008,11,30).holidays(:gb_sct, :informal)[0][:name]
 
     assert_equal 'Christmas Day', Date.civil(2008,12,25).holidays(:gb_, :observed)[0][:name]
     assert_equal 'Christmas Day', Date.civil(2009,12,25).holidays(:gb_, :observed)[0][:name]

--- a/lib/holidays/europe.rb
+++ b/lib/holidays/europe.rb
@@ -222,6 +222,7 @@ module Holidays
             {:mday => 1, :name => "Toussaint", :regions => [:fr]},
             {:mday => 11, :name => "Armistice 1918", :regions => [:fr]},
             {:mday => 5, :type => :informal, :name => "Guy Fawkes Day", :regions => [:gb]},
+            {:mday => 30, :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :type => :informal, :name => "St. Andrew's Day", :regions => [:gb_sct]},
             {:mday => 1, :name => "Dan svih svetih", :regions => [:hr]},
             {:mday => 1, :name => "Mindenszentek", :regions => [:hu]},
             {:mday => 16, :name => "Dagur íslenskrar tungu", :regions => [:is]},

--- a/lib/holidays/gb.rb
+++ b/lib/holidays/gb.rb
@@ -32,7 +32,8 @@ module Holidays
             {:mday => 12, :name => "Battle of the Boyne", :regions => [:gb_nir]}],
       8 => [{:wday => 1, :week => 1, :name => "Bank Holiday", :regions => [:gb_sct]},
             {:wday => 1, :week => -1, :name => "Bank Holiday", :regions => [:gb_eng, :gb_wls, :gb_eaw, :gb_nir]}],
-      11 => [{:mday => 5, :type => :informal, :name => "Guy Fawkes Day", :regions => [:gb]}],
+      11 => [{:mday => 5, :type => :informal, :name => "Guy Fawkes Day", :regions => [:gb]},
+            {:mday => 30, :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :type => :informal, :name => "St. Andrew's Day", :regions => [:gb_sct]}],
       12 => [{:mday => 25, :observed => lambda { |date| Holidays.to_monday_if_weekend(date) }, :observed_id => "to_monday_if_weekend", :name => "Christmas Day", :regions => [:gb]},
             {:mday => 26, :observed => lambda { |date| Holidays.to_weekday_if_boxing_weekend(date) }, :observed_id => "to_weekday_if_boxing_weekend", :name => "Boxing Day", :regions => [:gb]}]
       }

--- a/test/defs/test_defs_europe.rb
+++ b/test/defs/test_defs_europe.rb
@@ -238,6 +238,7 @@ end
 end
 
 assert_equal 'St. Patrick\'s Day', Date.civil(2008,3,17).holidays(:gb_nir, :informal)[0][:name]
+assert_equal 'St. Andrew\'s Day', Date.civil(2008,11,30).holidays(:gb_sct, :informal)[0][:name]
 
 assert_equal 'Christmas Day', Date.civil(2008,12,25).holidays(:gb_, :observed)[0][:name]
 assert_equal 'Christmas Day', Date.civil(2009,12,25).holidays(:gb_, :observed)[0][:name]

--- a/test/defs/test_defs_gb.rb
+++ b/test/defs/test_defs_gb.rb
@@ -18,6 +18,7 @@ class GbDefinitionTests < Test::Unit::TestCase  # :nodoc:
 end
 
 assert_equal 'St. Patrick\'s Day', Date.civil(2008,3,17).holidays(:gb_nir, :informal)[0][:name]
+assert_equal 'St. Andrew\'s Day', Date.civil(2008,11,30).holidays(:gb_sct, :informal)[0][:name]
 
 assert_equal 'Christmas Day', Date.civil(2008,12,25).holidays(:gb_, :observed)[0][:name]
 assert_equal 'Christmas Day', Date.civil(2009,12,25).holidays(:gb_, :observed)[0][:name]


### PR DESCRIPTION
Amended definition for the holiday the day after New Year's Day in gb_sct, it is more commonly referred to as "2nd January". It also behaves similarly to Boxing Day when it falls on a weekend.

Added St Andrew's Day to gb_sct as an informal holiday since it is not widely observed currently.
