### PR TITLE
When no regions are loaded, accessing a subregion fails.

### DIFF
--- a/test/test_all_regions.rb
+++ b/test/test_all_regions.rb
@@ -5,35 +5,35 @@ class MultipleRegionsTests < Test::Unit::TestCase
   def test_definition_dir
     assert File.directory?(Holidays::DEFINITION_PATH)
   end
-  
+
   def test_getting_available_paths
     defs = Holidays.available(true)
     assert_equal def_count, defs.size
-    
+
     defs.each do |f|
       assert f.kind_of?(String)
       assert File.exists?(f)
     end
   end
-  
+
   def test_getting_available_symbols
     defs = Holidays.available(false)
     assert_equal def_count, defs.size
-    
+
     defs.each { |f| assert f.kind_of?(Symbol) }
-    
+
     # some spot checks
     assert defs.include?(:ca)
     assert defs.include?(:united_nations)
   end
 
-  
+
   def test_loading_all
     Holidays.load_all
     holidays = Holidays.on(Date.civil(2011, 5, 1), :any)
 
     # at least 15 now, but there could be more in the future
-    assert holidays.size > 15 
+    assert holidays.size > 15
 
     # some spot checks
     assert holidays.any? { |h| h[:name] == 'Staatsfeiertag' }  # :at
@@ -50,9 +50,17 @@ class MultipleRegionsTests < Test::Unit::TestCase
     assert regions.include? :nyse
     assert regions.include? :united_nations
   end
-  
+
+  def test_load_subregion
+    Holidays.send(:remove_const, :DE) #unload de module so that is has to be loaded again
+    Holidays.send(:class_variable_set, :@@regions, []) # reset regions
+    holidays = Holidays.on(Date.civil(2014, 1, 1), :de_bb)
+
+    assert holidays.any? { |h| h[:name] == 'Neujahrstag' }
+  end
+
 private
   def def_count
     Dir.glob(Holidays::DEFINITION_PATH + '/*.rb').size
-  end  
+  end
 end


### PR DESCRIPTION
This problem was already addressed by pull request #64 by [Goltergaul](https://github.com/Goltergaul). However, his tests were failing for Ruby 1.8.7, and since I needed this for a project that runs under 1.8.7 I had to fix them anyway. Also, I thought I'd try for code that is a little closer to your style of writing - whether I have achieved this remains for you to decide.

In order to prove beforehand that the tests pass, I have submitted my fork to Travis. You can view the build results for the branch this pull request comes from [over there](https://travis-ci.org/capita/holidays/builds/35971115).

Please note that the problem addressed in pull request #71 by [rojoko](https://github.com/rojoko) also gets solved by this fix. 

To restate the problems:
- The holiday definition for a region is not loaded implicitly when you try to access one of its subregions that has a holiday definition of its own:

```
Christians-MacBook-Pro-2:holidays csage$ git co 9b69c9b
...
HEAD is now at 9b69c9b... SG: add stray April Fool's informal
Christians-MacBook-Pro-2:holidays csage$ bundle exec irb
2.1.3 :001 > require 'holidays'
 => true
2.1.3 :002 > Date.today.holiday? :de_bb
Holidays::UnknownRegionError: Could not load holidays/de_bb
    from /Users/csage/Projects/holidays/lib/holidays.rb:360:in `rescue in block in parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:357:in `block in parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:355:in `each'
    from /Users/csage/Projects/holidays/lib/holidays.rb:355:in `parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:320:in `parse_options'
    from /Users/csage/Projects/holidays/lib/holidays.rb:122:in `between'
    from /Users/csage/Projects/holidays/lib/holidays.rb:68:in `on'
    from /Users/csage/Projects/holidays/lib/holidays.rb:445:in `holidays'
    from /Users/csage/Projects/holidays/lib/holidays.rb:455:in `holiday?'
    from (irb):2
    from /Users/csage/.rvm/rubies/ruby-2.1.3/bin/irb:11:in `<main>'
2.1.3 :003 > Date.today.holiday? :de
 => false
2.1.3 :004 > Date.today.holiday? :de_bb
 => false
```
- Trying to access a subregion with no holiday specifications of its own fails. That is true even after the containing region has been loaded:

```
Christians-MacBook-Pro-2:holidays csage$ git co 9b69c9b
...
HEAD is now at 9b69c9b... SG: add stray April Fool's informal
Christians-MacBook-Pro-2:holidays csage$ bundle exec irb
2.1.3 :001 > require 'holidays'
 => true
2.1.3 :002 > Date.today.holiday? :de_be
Holidays::UnknownRegionError: Could not load holidays/de_be
    from /Users/csage/Projects/holidays/lib/holidays.rb:360:in `rescue in block in parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:357:in `block in parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:355:in `each'
    from /Users/csage/Projects/holidays/lib/holidays.rb:355:in `parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:320:in `parse_options'
    from /Users/csage/Projects/holidays/lib/holidays.rb:122:in `between'
    from /Users/csage/Projects/holidays/lib/holidays.rb:68:in `on'
    from /Users/csage/Projects/holidays/lib/holidays.rb:445:in `holidays'
    from /Users/csage/Projects/holidays/lib/holidays.rb:455:in `holiday?'
    from (irb):2
    from /Users/csage/.rvm/rubies/ruby-2.1.3/bin/irb:11:in `<main>'
2.1.3 :003 > Date.today.holiday? :de
 => false
2.1.3 :004 > Date.today.holiday? :de_be
Holidays::UnknownRegionError: Could not load holidays/de_be
    from /Users/csage/Projects/holidays/lib/holidays.rb:360:in `rescue in block in parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:357:in `block in parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:355:in `each'
    from /Users/csage/Projects/holidays/lib/holidays.rb:355:in `parse_regions'
    from /Users/csage/Projects/holidays/lib/holidays.rb:320:in `parse_options'
    from /Users/csage/Projects/holidays/lib/holidays.rb:122:in `between'
    from /Users/csage/Projects/holidays/lib/holidays.rb:68:in `on'
    from /Users/csage/Projects/holidays/lib/holidays.rb:445:in `holidays'
    from /Users/csage/Projects/holidays/lib/holidays.rb:455:in `holiday?'
    from (irb):4
    from /Users/csage/.rvm/rubies/ruby-2.1.3/bin/irb:11:in `<main>'
```

Having the possibility to directly access the holidays for a specific subregion irrespective of its having any would be very convenient in the context of federal states, where address data usually includes the state (= the subregion). 

Both problems go away with this pull request, the feature desired by rojoko and myself becomes a one-liner:

```
Christians-MacBook-Pro-2:holidays csage$ git co subregion_load
...
Switched to a new branch 'subregion_load'
Christians-MacBook-Pro-2:holidays csage$ bundle exec irb
2.1.3 :001 > require 'holidays'
 => true
2.1.3 :002 > Date.today.holiday? :de_be
 => false
```

My apologies for the mess I made in the comments of the pull requests I have referenced here. Before this I sadly lacked experience with creating pull requests, so it took me several tries to get it even approximately right. 
