### PR TITLE
Update Canadian holidays

### DIFF
--- a/data/ca.yaml
+++ b/data/ca.yaml
@@ -1,5 +1,5 @@
 # Canadian holiday definitions for the Ruby Holiday gem.
-# Updated 2008-11-21.
+# Updated 2014-11-12.
 ---
 months:
   0:
@@ -29,7 +29,15 @@ months:
     regions: [ca_mb]
     wday: 1
     week: 3
-  - name: BC Family Day
+  - name: Nova Scotia Heritage Day # Ideally would be restricted to 2015 or later
+    regions: [ca_ns]
+    wday: 1
+    week: 3
+  - name: Islander Day
+    regions: [ca_pe]
+    wday: 1
+    week: 3
+  - name: BC Family Day # Ideally would be restricted to 2013 or later
     regions: [ca_bc]
     wday: 1
     week: 2
@@ -88,7 +96,11 @@ months:
     wday: 1
   - name: Civic Holiday
     week: 1
-    regions: [ca_on]
+    regions: [ca_on, ca_nt, ca_nu, ca_pe] # Appears to be a holiday in Ontario by convention
+    wday: 1
+  - name: New Brunswick Day
+    week: 1
+    regions: [ca_nb]
     wday: 1
   - name: Discovery Day
     week: 3
@@ -147,8 +159,33 @@ tests: |
       assert_equal 'BC Family Day', Holidays.on(date, :ca_bc)[0][:name]
     end
 
+    # Nova Scotia Heritage Day
+    [ Date.civil(2015,2,16), Date.civil(2016,2,15) ].each do |date|
+      assert_equal 'Nova Scotia Heritage Day', Holidays.on(date, :ca_ns)[0][:name]
+    end
+
+    # Islander Day in PE
+    [ Date.civil(2013,2,18), Date.civil(2014,2,17) ].each do |date|
+      assert_equal 'Islander Day', Holidays.on(date, :ca_pe)[0][:name]
+    end
+
     # Victoria Day
     [Date.civil(2004,5,24), Date.civil(2005,5,23), Date.civil(2006,5,22),
      Date.civil(2007,5,21), Date.civil(2008,5,19)].each do |date|
       assert_equal 'Victoria Day', Holidays.on(date, :ca)[0][:name]
+    end
+
+    # First Monday in August
+    [Date.civil(2013,8,5), Date.civil(2014,8,4), Date.civil(2015,8,3)].each do |date|
+      { :ca_bc => 'BC Day',
+        :ca_sk => 'Saskatchewan Day',
+        :ca_ab => 'Heritage Day',
+        :ca_ns => 'Natal Day',
+        :ca_on => 'Civic Holiday',
+        :ca_nt => 'Civic Holiday',
+        :ca_nu => 'Civic Holiday',
+        :ca_pe => 'Civic Holiday',
+        :ca_nb => 'New Brunswick Day' }.each do |region, name|
+        assert_equal name, Holidays.on(date, region)[0][:name]
+      end
     end

--- a/lib/holidays/ca.rb
+++ b/lib/holidays/ca.rb
@@ -13,7 +13,7 @@ module Holidays
   # All the definitions are available at https://github.com/alexdunae/holidays
   module CA # :nodoc:
     def self.defined_regions
-      [:ca, :ca_qc, :ca_ab, :ca_on, :ca_sk, :ca_mb, :ca_bc, :ca_nf, :ca_nt, :ca_nu, :ca_ns, :ca_yk, :us]
+      [:ca, :ca_qc, :ca_ab, :ca_on, :ca_sk, :ca_mb, :ca_ns, :ca_pe, :ca_bc, :ca_nf, :ca_nt, :ca_nu, :ca_nb, :ca_yk, :us]
     end
 
     def self.holidays_by_month
@@ -25,6 +25,8 @@ module Holidays
             {:mday => 2, :name => "New Year's", :regions => [:ca_qc]}],
       2 => [{:wday => 1, :week => 3, :name => "Family Day", :regions => [:ca_ab, :ca_on, :ca_sk]},
             {:wday => 1, :week => 3, :name => "Louis Riel Day", :regions => [:ca_mb]},
+            {:wday => 1, :week => 3, :name => "Nova Scotia Heritage Day", :regions => [:ca_ns]},
+            {:wday => 1, :week => 3, :name => "Islander Day", :regions => [:ca_pe]},
             {:wday => 1, :week => 2, :name => "BC Family Day", :regions => [:ca_bc]},
             {:mday => 2, :type => :informal, :name => "Groundhog Day", :regions => [:us, :ca]},
             {:mday => 14, :type => :informal, :name => "Valentine's Day", :regions => [:us, :ca]}],
@@ -45,7 +47,8 @@ module Holidays
             {:wday => 1, :week => 1, :name => "Saskatchewan Day", :regions => [:ca_sk]},
             {:wday => 1, :week => 1, :name => "Heritage Day", :regions => [:ca_ab]},
             {:wday => 1, :week => 1, :name => "Natal Day", :regions => [:ca_ns]},
-            {:wday => 1, :week => 1, :name => "Civic Holiday", :regions => [:ca_on]},
+            {:wday => 1, :week => 1, :name => "Civic Holiday", :regions => [:ca_on, :ca_nt, :ca_nu, :ca_pe]},
+            {:wday => 1, :week => 1, :name => "New Brunswick Day", :regions => [:ca_nb]},
             {:wday => 1, :week => 3, :name => "Discovery Day", :regions => [:ca_yk]}],
       9 => [{:wday => 1, :week => 1, :name => "Labour Day", :regions => [:ca]}],
       10 => [{:wday => 1, :week => 2, :name => "Thanksgiving", :regions => [:ca]},

--- a/lib/holidays/north_america.rb
+++ b/lib/holidays/north_america.rb
@@ -13,7 +13,7 @@ module Holidays
   # All the definitions are available at https://github.com/alexdunae/holidays
   module North_America # :nodoc:
     def self.defined_regions
-      [:ca, :ca_qc, :ca_ab, :ca_on, :ca_sk, :ca_mb, :ca_bc, :ca_nf, :ca_nt, :ca_nu, :ca_ns, :ca_yk, :mx, :mx_pue, :us, :us_dc]
+      [:ca, :ca_qc, :ca_ab, :ca_on, :ca_sk, :ca_mb, :ca_ns, :ca_pe, :ca_bc, :ca_nf, :ca_nt, :ca_nu, :ca_nb, :ca_yk, :mx, :mx_pue, :us, :us_dc]
     end
 
     def self.holidays_by_month
@@ -32,6 +32,8 @@ module Holidays
             {:function => lambda { |year| Holidays.us_inauguration_day(year) }, :function_id => "us_inauguration_day(year)", :name => "Inauguration Day", :regions => [:us_dc]}],
       2 => [{:wday => 1, :week => 3, :name => "Family Day", :regions => [:ca_ab, :ca_on, :ca_sk]},
             {:wday => 1, :week => 3, :name => "Louis Riel Day", :regions => [:ca_mb]},
+            {:wday => 1, :week => 3, :name => "Nova Scotia Heritage Day", :regions => [:ca_ns]},
+            {:wday => 1, :week => 3, :name => "Islander Day", :regions => [:ca_pe]},
             {:wday => 1, :week => 2, :name => "BC Family Day", :regions => [:ca_bc]},
             {:wday => 1, :week => 1, :name => "Día de la Constitución", :regions => [:mx]},
             {:wday => 1, :week => 3, :name => "Presidents' Day", :regions => [:us]},
@@ -63,7 +65,8 @@ module Holidays
             {:wday => 1, :week => 1, :name => "Saskatchewan Day", :regions => [:ca_sk]},
             {:wday => 1, :week => 1, :name => "Heritage Day", :regions => [:ca_ab]},
             {:wday => 1, :week => 1, :name => "Natal Day", :regions => [:ca_ns]},
-            {:wday => 1, :week => 1, :name => "Civic Holiday", :regions => [:ca_on]},
+            {:wday => 1, :week => 1, :name => "Civic Holiday", :regions => [:ca_on, :ca_nt, :ca_nu, :ca_pe]},
+            {:wday => 1, :week => 1, :name => "New Brunswick Day", :regions => [:ca_nb]},
             {:wday => 1, :week => 3, :name => "Discovery Day", :regions => [:ca_yk]}],
       9 => [{:wday => 1, :week => 1, :name => "Labour Day", :regions => [:ca]},
             {:mday => 15, :name => "Grito de Dolores", :regions => [:mx]},

--- a/test/defs/test_defs_ca.rb
+++ b/test/defs/test_defs_ca.rb
@@ -26,10 +26,35 @@ end
   assert_equal 'BC Family Day', Holidays.on(date, :ca_bc)[0][:name]
 end
 
+# Nova Scotia Heritage Day
+[ Date.civil(2015,2,16), Date.civil(2016,2,15) ].each do |date|
+  assert_equal 'Nova Scotia Heritage Day', Holidays.on(date, :ca_ns)[0][:name]
+end
+
+# Islander Day in PE
+[ Date.civil(2013,2,18), Date.civil(2014,2,17) ].each do |date|
+  assert_equal 'Islander Day', Holidays.on(date, :ca_pe)[0][:name]
+end
+
 # Victoria Day
 [Date.civil(2004,5,24), Date.civil(2005,5,23), Date.civil(2006,5,22),
  Date.civil(2007,5,21), Date.civil(2008,5,19)].each do |date|
   assert_equal 'Victoria Day', Holidays.on(date, :ca)[0][:name]
+end
+
+# First Monday in August
+[Date.civil(2013,8,5), Date.civil(2014,8,4), Date.civil(2015,8,3)].each do |date|
+  { :ca_bc => 'BC Day',
+    :ca_sk => 'Saskatchewan Day',
+    :ca_ab => 'Heritage Day',
+    :ca_ns => 'Natal Day',
+    :ca_on => 'Civic Holiday',
+    :ca_nt => 'Civic Holiday',
+    :ca_nu => 'Civic Holiday',
+    :ca_pe => 'Civic Holiday',
+    :ca_nb => 'New Brunswick Day' }.each do |region, name|
+    assert_equal name, Holidays.on(date, region)[0][:name]
+  end
 end
 
 

--- a/test/defs/test_defs_north_america.rb
+++ b/test/defs/test_defs_north_america.rb
@@ -26,10 +26,35 @@ end
   assert_equal 'BC Family Day', Holidays.on(date, :ca_bc)[0][:name]
 end
 
+# Nova Scotia Heritage Day
+[ Date.civil(2015,2,16), Date.civil(2016,2,15) ].each do |date|
+  assert_equal 'Nova Scotia Heritage Day', Holidays.on(date, :ca_ns)[0][:name]
+end
+
+# Islander Day in PE
+[ Date.civil(2013,2,18), Date.civil(2014,2,17) ].each do |date|
+  assert_equal 'Islander Day', Holidays.on(date, :ca_pe)[0][:name]
+end
+
 # Victoria Day
 [Date.civil(2004,5,24), Date.civil(2005,5,23), Date.civil(2006,5,22),
  Date.civil(2007,5,21), Date.civil(2008,5,19)].each do |date|
   assert_equal 'Victoria Day', Holidays.on(date, :ca)[0][:name]
+end
+
+# First Monday in August
+[Date.civil(2013,8,5), Date.civil(2014,8,4), Date.civil(2015,8,3)].each do |date|
+  { :ca_bc => 'BC Day',
+    :ca_sk => 'Saskatchewan Day',
+    :ca_ab => 'Heritage Day',
+    :ca_ns => 'Natal Day',
+    :ca_on => 'Civic Holiday',
+    :ca_nt => 'Civic Holiday',
+    :ca_nu => 'Civic Holiday',
+    :ca_pe => 'Civic Holiday',
+    :ca_nb => 'New Brunswick Day' }.each do |region, name|
+    assert_equal name, Holidays.on(date, region)[0][:name]
+  end
 end
 
 


### PR DESCRIPTION
- Add Nova Scotia Heritage Day, falling on the third Monday of
  February from 2015.
  (https://en.wikipedia.org/wiki/Islander_Day#Nova_Scotia_Heritage_Day)
- Add Islander Day for Prince Edward Island, falling on the third
  Monday of February.
  (https://en.wikipedia.org/wiki/Islander_Day#Islander_Day_.28Prince_Edward_Island.29)
- Add Northwest Territories, Nunavut, and Prince Edward Island to the
  list of regions to celebrate the first Monday of August as Civic
  Holiday.
  (https://en.wikipedia.org/wiki/Civic_Holiday)
- Add New Brunswick Day, falling on the first Monday of August.
  (https://en.wikipedia.org/wiki/Civic_Holiday)
- Add missing tests for the first Monday of August.
