### PR TITLE
Fix Ireland observance day for St. Stephen's Day when it falls on Saturday

### DIFF
--- a/definitions/ie.yaml
+++ b/definitions/ie.yaml
@@ -54,13 +54,14 @@ methods:
   ie_st_stephens_day: |
     # Ireland - Stephens Day is always the day after christmas day
     def self.ie_st_stephens_day(date)
-      date += 2 if date.wday == 6
-      date += 2 if date.wday == 0
-      date += 1 if date.wday == 1
-      date
+      case date.wday
+      when 6, 0 then date + 2
+      when 1 then date + 1
+      else date
+      end
     end
 tests: |
-    {Date.civil(2008,1,1) => 'New Year\'s Day', 
+    {Date.civil(2008,1,1) => 'New Year\'s Day',
      Date.civil(2008,3,17) => 'St. Patrick\'s Day',
      Date.civil(2008,3,24) => 'Easter Monday',
      Date.civil(2008,5,5) => 'May Day',
@@ -71,7 +72,7 @@ tests: |
      Date.civil(2008,12,26) => 'St. Stephen\'s Day'}.each do |date, name|
       assert_equal name, (Holidays.on(date, :ie)[0] || {})[:name]
     end
-    {Date.civil(2012,1,2) => 'New Year\'s Day', 
+    {Date.civil(2012,1,2) => 'New Year\'s Day',
      Date.civil(2012,3,19) => 'St. Patrick\'s Day',
      Date.civil(2012,4,9) => 'Easter Monday',
      Date.civil(2012,5,7) => 'May Day',
@@ -81,6 +82,7 @@ tests: |
      Date.civil(2011,12,26) => 'Christmas Day',
      Date.civil(2011,12,27) => 'St. Stephen\'s Day',
      Date.civil(2012,12,25) => 'Christmas Day',
-     Date.civil(2012,12,26) => 'St. Stephen\'s Day'}.each do |date, name|
+     Date.civil(2012,12,26) => 'St. Stephen\'s Day',
+     Date.civil(2015,12,28) => 'St. Stephen\'s Day'}.each do |date, name|
       assert_equal name, (Holidays.on(date, :ie, :observed)[0] || {})[:name]
     end

--- a/lib/generated_definitions/europe.rb
+++ b/lib/generated_definitions/europe.rb
@@ -475,10 +475,11 @@ end
 
 # Ireland - Stephens Day is always the day after christmas day
 def self.ie_st_stephens_day(date)
-  date += 2 if date.wday == 6
-  date += 2 if date.wday == 0
-  date += 1 if date.wday == 1
-  date
+  case date.wday
+  when 6, 0 then date + 2
+  when 1 then date + 1
+  else date
+  end
 end
 
 

--- a/lib/generated_definitions/ie.rb
+++ b/lib/generated_definitions/ie.rb
@@ -33,10 +33,11 @@ module Holidays
 
 # Ireland - Stephens Day is always the day after christmas day
 def self.ie_st_stephens_day(date)
-  date += 2 if date.wday == 6
-  date += 2 if date.wday == 0
-  date += 1 if date.wday == 1
-  date
+  case date.wday
+  when 6, 0 then date + 2
+  when 1 then date + 1
+  else date
+  end
 end
 
 

--- a/test/defs/test_defs_europe.rb
+++ b/test/defs/test_defs_europe.rb
@@ -334,7 +334,7 @@ end
 assert_equal [], Holidays.on(Date.civil(2012,3,14), :hu), '2012-03-14 is not a holiday in Hungary'
 
 
-{Date.civil(2008,1,1) => 'New Year\'s Day', 
+{Date.civil(2008,1,1) => 'New Year\'s Day',
  Date.civil(2008,3,17) => 'St. Patrick\'s Day',
  Date.civil(2008,3,24) => 'Easter Monday',
  Date.civil(2008,5,5) => 'May Day',
@@ -345,7 +345,7 @@ assert_equal [], Holidays.on(Date.civil(2012,3,14), :hu), '2012-03-14 is not a h
  Date.civil(2008,12,26) => 'St. Stephen\'s Day'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :ie)[0] || {})[:name]
 end
-{Date.civil(2012,1,2) => 'New Year\'s Day', 
+{Date.civil(2012,1,2) => 'New Year\'s Day',
  Date.civil(2012,3,19) => 'St. Patrick\'s Day',
  Date.civil(2012,4,9) => 'Easter Monday',
  Date.civil(2012,5,7) => 'May Day',
@@ -355,7 +355,8 @@ end
  Date.civil(2011,12,26) => 'Christmas Day',
  Date.civil(2011,12,27) => 'St. Stephen\'s Day',
  Date.civil(2012,12,25) => 'Christmas Day',
- Date.civil(2012,12,26) => 'St. Stephen\'s Day'}.each do |date, name|
+ Date.civil(2012,12,26) => 'St. Stephen\'s Day',
+ Date.civil(2015,12,28) => 'St. Stephen\'s Day'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :ie, :observed)[0] || {})[:name]
 end
 

--- a/test/defs/test_defs_ie.rb
+++ b/test/defs/test_defs_ie.rb
@@ -7,7 +7,7 @@ require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
 class IeDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
   def test_ie
-{Date.civil(2008,1,1) => 'New Year\'s Day', 
+{Date.civil(2008,1,1) => 'New Year\'s Day',
  Date.civil(2008,3,17) => 'St. Patrick\'s Day',
  Date.civil(2008,3,24) => 'Easter Monday',
  Date.civil(2008,5,5) => 'May Day',
@@ -18,7 +18,7 @@ class IeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2008,12,26) => 'St. Stephen\'s Day'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :ie)[0] || {})[:name]
 end
-{Date.civil(2012,1,2) => 'New Year\'s Day', 
+{Date.civil(2012,1,2) => 'New Year\'s Day',
  Date.civil(2012,3,19) => 'St. Patrick\'s Day',
  Date.civil(2012,4,9) => 'Easter Monday',
  Date.civil(2012,5,7) => 'May Day',
@@ -28,7 +28,8 @@ end
  Date.civil(2011,12,26) => 'Christmas Day',
  Date.civil(2011,12,27) => 'St. Stephen\'s Day',
  Date.civil(2012,12,25) => 'Christmas Day',
- Date.civil(2012,12,26) => 'St. Stephen\'s Day'}.each do |date, name|
+ Date.civil(2012,12,26) => 'St. Stephen\'s Day',
+ Date.civil(2015,12,28) => 'St. Stephen\'s Day'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :ie, :observed)[0] || {})[:name]
 end
 


### PR DESCRIPTION
When St. Stephen's Day falls on Saturday this year, I think it should be observed on Monday (I'm not Irish). Currently, holidays is saying it should be observed on Tuesday. This may be a subtle bug where the `date.wday` checks are falling-through when there's not a reason to do so: so when it's Saturday, lines 57 and 59 end up modifying the date.