### PR TITLE
require digest/md5 which is used

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -2,6 +2,7 @@
 $:.unshift File.dirname(__FILE__)
 
 require 'date'
+require 'digest/md5'
 require 'holidays/definition_factory'
 require 'holidays/date_calculator_factory'
 require 'holidays/option_factory'


### PR DESCRIPTION
Tests were passing since digest is required by test suite gems.

This was failing:
```
require 'holidays'
irb(main):002:0> date = Date.civil(2008,4,25)
=> #<Date: 2008-04-25 ((2454582j,0s,0n),+0s,2299161j)>
irb(main):003:0> Holidays.on(date, :au)
NameError: uninitialized constant Holidays::Definition::Repository::ProcCache::Digest
	from holidays-3.1.0/lib/holidays/definition/repository/proc_cache.rb:29:in `lookup'
```