### PR TITLE
Refactor to prefer full names rather than extended core ruby classes internally

### DIFF
--- a/definitions/au.yaml
+++ b/definitions/au.yaml
@@ -193,7 +193,7 @@ methods:
       if year < 2006
         nil
       else
-        Date.civil(year, 3, Date.calculate_mday(year, 3, :second, :monday))
+        Date.civil(year, 3, Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 3, :second, :monday))
       end
     end
   may_pub_hol_sa: |
@@ -203,7 +203,7 @@ methods:
       if year >= 2006
         nil
       else
-        Date.civil(year, 5, Date.calculate_mday(year, 5, :third, :monday))
+        Date.civil(year, 5, Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 5, :third, :monday))
       end
     end
 tests: |

--- a/definitions/us.yaml
+++ b/definitions/us.yaml
@@ -79,7 +79,7 @@ methods:
     end
   day_after_thanksgiving: |
     def self.day_after_thanksgiving(year)
-      Date.calculate_mday(year, 11, 4, 4) + 1
+      Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 11, 4, 4) + 1
     end
 tests: |
     {Date.civil(2008,1,1) => 'New Year\'s Day',

--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -106,7 +106,7 @@ def self.march_pub_hol_sa(year)
   if year < 2006
     nil
   else
-    Date.civil(year, 3, Date.calculate_mday(year, 3, :second, :monday))
+    Date.civil(year, 3, Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 3, :second, :monday))
   end
 end
 
@@ -117,7 +117,7 @@ def self.may_pub_hol_sa(year)
   if year >= 2006
     nil
   else
-    Date.civil(year, 5, Date.calculate_mday(year, 5, :third, :monday))
+    Date.civil(year, 5, Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 5, :third, :monday))
   end
 end
 

--- a/lib/generated_definitions/fed_ex.rb
+++ b/lib/generated_definitions/fed_ex.rb
@@ -31,7 +31,7 @@ module Holidays
   end
 
 def self.day_after_thanksgiving(year)
-  Date.calculate_mday(year, 11, 4, 4) + 1
+  Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 11, 4, 4) + 1
 end
 
 

--- a/lib/generated_definitions/north_america.rb
+++ b/lib/generated_definitions/north_america.rb
@@ -117,7 +117,7 @@ end
 
 
 def self.day_after_thanksgiving(year)
-  Date.calculate_mday(year, 11, 4, 4) + 1
+  Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 11, 4, 4) + 1
 end
 
 

--- a/lib/generated_definitions/ups.rb
+++ b/lib/generated_definitions/ups.rb
@@ -31,7 +31,7 @@ module Holidays
   end
 
 def self.day_after_thanksgiving(year)
-  Date.calculate_mday(year, 11, 4, 4) + 1
+  Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 11, 4, 4) + 1
 end
 
 

--- a/lib/generated_definitions/us.rb
+++ b/lib/generated_definitions/us.rb
@@ -53,7 +53,7 @@ end
 
 
 def self.day_after_thanksgiving(year)
-  Date.calculate_mday(year, 11, 4, 4) + 1
+  Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 11, 4, 4) + 1
 end
 
 

--- a/lib/holidays/date_calculator/day_of_month.rb
+++ b/lib/holidays/date_calculator/day_of_month.rb
@@ -15,15 +15,15 @@ module Holidays
     #
     # ===== Examples
     # First Monday of January, 2008:
-    #   Date.calculate_mday(2008, 1, :first, :monday)
+    #   Holidays::DateCalculatorFactory.day_of_month_calculator.call(2008, 1, :first, :monday)
     #   => 7
     #
     # Third Thursday of December, 2008:
-    #   Date.calculate_mday(2008, 12, :third, :thursday)
+    #   Holidays::DateCalculatorFactory.day_of_month_calculator.call(2008, 12, :third, :thursday)
     #   => 18
     #
     # Last Monday of January, 2008:
-    #   Date.calculate_mday(2008, 1, :last, 1)
+    #   Holidays::DateCalculatorFactory.day_of_month_calculator.call(2008, 1, :last, 1)
     #   => 28
     #--
     # see http://www.irt.org/articles/js050/index.htm


### PR DESCRIPTION
Fixes #154 Refactor to prefer Holidays::DateCalculatorFactory.day_of_month_calculator.call over Date.calculate_mday; which is an alias for the above method.