### PR TITLE
Support older rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ notifications:
   disabled: true
 sudo: false
 rvm:
+  - ree
+  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,15 @@
 source 'https://rubygems.org'
 
 gemspec
+
+platform :ruby_18 do
+  group :test do
+    gem 'rake'
+
+    # For coveralls support
+    gem 'mime-types', '~> 1.0'
+    gem 'rest-client', '~> 1.6.7'
+
+    gem 'test-unit', '~> 1.2.3'
+  end
+end

--- a/lib/holidays/option_factory.rb
+++ b/lib/holidays/option_factory.rb
@@ -6,7 +6,7 @@ module Holidays
       def parse_options
         Option::Context::ParseOptions.new(
           DefinitionFactory.regions_repository,
-          DefinitionFactory.region_validator,
+          DefinitionFactory.region_validator
         )
       end
     end

--- a/lib/holidays/use_case_factory.rb
+++ b/lib/holidays/use_case_factory.rb
@@ -8,7 +8,7 @@ module Holidays
         UseCase::Context::Between.new(
           DefinitionFactory.holidays_by_month_repository,
           DateCalculatorFactory.day_of_month_calculator,
-          DefinitionFactory.proc_cache_repository,
+          DefinitionFactory.proc_cache_repository
         )
       end
 

--- a/test/holidays/option/context/test_parse_options.rb
+++ b/test/holidays/option/context/test_parse_options.rb
@@ -17,7 +17,7 @@ class ParseOptionsTests < Test::Unit::TestCase
 
     @subject = Holidays::Option::Context::ParseOptions.new(
       @regions_repo,
-      @region_validator,
+      @region_validator
     )
   end
 

--- a/test/holidays/use_case/context/test_between.rb
+++ b/test/holidays/use_case/context/test_between.rb
@@ -14,7 +14,7 @@ class BetweenTests < Test::Unit::TestCase
     @subject = Holidays::UseCase::Context::Between.new(
       @holidays_by_month_repo,
       @day_of_month_calculator,
-      @proc_cache_repo,
+      @proc_cache_repo
     )
 
     @start_date = Date.civil(2015, 1, 1)

--- a/test/test_holidays_between.rb
+++ b/test/test_holidays_between.rb
@@ -46,9 +46,9 @@ class HolidaysTests < Test::Unit::TestCase
     end_date = Date.civil(2015, 1, 31)
     options = [:us, :informal]
 
-    Holidays::DefinitionFactory.cache_repository.expects(:find).with(start_date, end_date, options).returns({cached: 'data'})
+    Holidays::DefinitionFactory.cache_repository.expects(:find).with(start_date, end_date, options).returns({:cached => 'data'})
 
-    assert_equal({cached: 'data'}, @subject.call(start_date, end_date, *options))
+    assert_equal({:cached => 'data'}, @subject.call(start_date, end_date, *options))
   end
 
   def test_options_are_parsed


### PR DESCRIPTION
We have a [gem](https://github.com/enova/business_calendar) that depends on this one,
and we'd like to upgrade, but we still need to support REE.