### PR TITLE
Add method to calculate holidays for duration of year

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -160,6 +160,50 @@ module Holidays
       UseCaseFactory.next_holiday.call(holidays_count, from_date, date_driver_hash, regions, observed, informal)
     end
 
+    # Get all holidays occuring from date to end of year, inclusively. 
+    #
+    # Returns an array of hashes or nil. 
+    #
+    # Incoming arguments are below: 
+    # [<tt>options</tt>]  One or more region symbols, <tt>:informal</tt> and/or <tt>:observed</tt>.
+    # [<tt>from_date</tt>]    Ruby Date object. This is an optional param, defaulted today.
+    #
+    # ==== Example
+    #   Date.today
+    #   => Tue, 23 Feb 2016
+    # 
+    #   regions = [:ca_on]
+    # 
+    #   Holidays.year_holidays(regions)
+    #   => [{:name=>"Good Friday",...},
+    #       {name=>"Easter Sunday",...},
+    #       {:name=>"Victoria Day",...},
+    #       {:name=>"Canada Day",...},
+    #       {:name=>"Civic Holiday",...},
+    #       {:name=>"Labour Day",...},
+    #       {:name=>"Thanksgiving",...},
+    #       {:name=>"Remembrance Day",...},
+    #       {:name=>"Christmas Day",...},
+    #       {:name=>"Boxing Day",...}]
+    def year_holidays(options, from_date = Date.today)
+      raise ArgumentError if options.empty?
+      raise ArgumentError unless options.is_a?(Array)
+
+      # remove the timezone
+      from_date = from_date.new_offset(0) + from_date.offset if from_date.respond_to?(:new_offset)
+
+      from_date = get_date(from_date)
+      to_date = from_date.to_datetime.change(:month => 12).end_of_month.to_date
+      regions, observed, informal = OptionFactory.parse_options.call(options)
+
+      # This could be smarter but I don't have any evidence that just checking for
+      # the next 12 months will cause us issues. If it does we can implement something
+      # smarter here to check in smaller increments.
+      date_driver_hash = UseCaseFactory.dates_driver_builder.call(from_date, from_date >> 12)
+
+      UseCaseFactory.year_holiday.call(from_date, to_date, date_driver_hash, regions, observed, informal)
+    end
+
     # Allows a developer to explicitly calculate and cache holidays within a given period
     def cache_between(start_date, end_date, *options)
       start_date, end_date = get_date(start_date), get_date(end_date)

--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -193,7 +193,7 @@ module Holidays
       from_date = from_date.new_offset(0) + from_date.offset if from_date.respond_to?(:new_offset)
 
       from_date = get_date(from_date)
-      to_date = from_date.to_datetime.change(:month => 12).end_of_month.to_date
+      to_date = Date.new(from_date.year, 12, 31)
       regions, observed, informal = OptionFactory.parse_options.call(options)
 
       # This could be smarter but I don't have any evidence that just checking for

--- a/lib/holidays/core_extensions/date.rb
+++ b/lib/holidays/core_extensions/date.rb
@@ -29,6 +29,24 @@ module Holidays
         holidays && !holidays.empty?
       end
 
+      # Returns a new Date where one or more of the elements have been changed according to the +options+ parameter.
+      # The +options+ parameter is a hash with a combination of these keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>.
+      #
+      #   Date.new(2007, 5, 12).change(day: 1)               # => Date.new(2007, 5, 1)
+      #   Date.new(2007, 5, 12).change(year: 2005, month: 1) # => Date.new(2005, 1, 12)
+      def change(options)
+        ::Date.new(
+          options.fetch(:year, year),
+          options.fetch(:month, month),
+          options.fetch(:day, day)
+        )
+      end
+
+      def end_of_month
+        last_day = ::Time.days_in_month( self.month, self.year )
+        change(:day => last_day)
+      end
+
       module ClassMethods
         def calculate_mday(year, month, week, wday)
           Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, month, week, wday)

--- a/lib/holidays/core_extensions/time.rb
+++ b/lib/holidays/core_extensions/time.rb
@@ -1,0 +1,23 @@
+module Holidays
+  module CoreExtensions
+    module Time
+      def self.included(base)
+        base.extend ClassMethods
+      end
+     
+      module ClassMethods
+        COMMON_YEAR_DAYS_IN_MONTH = [nil, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+        # Returns the number of days in the given month.
+        # If no year is specified, it will use the current year.
+        def days_in_month(month, year = current.year)
+          if month == 2 && ::Date.gregorian_leap?(year)
+            29
+          else
+            COMMON_YEAR_DAYS_IN_MONTH[month]
+          end
+        end
+      end 
+    end
+  end
+end

--- a/lib/holidays/use_case/context/year_holiday.rb
+++ b/lib/holidays/use_case/context/year_holiday.rb
@@ -1,0 +1,51 @@
+module Holidays
+  module UseCase
+    module Context
+      class YearHoliday
+        include ContextCommon
+
+        def initialize(holidays_by_month_repo, day_of_month_calculator, custom_methods_repo, proc_result_cache_repo)
+          @holidays_by_month_repo = holidays_by_month_repo
+          @day_of_month_calculator = day_of_month_calculator
+          @custom_methods_repo = custom_methods_repo
+          @proc_result_cache_repo = proc_result_cache_repo
+        end
+
+        def call(from_date, to_date, dates_driver, regions, observed, informal)
+          validate!(from_date, to_date, dates_driver, regions)
+          holidays = []
+          ret_holidays = []
+
+          ret_holidays = make_date_array(dates_driver, regions, observed, informal)
+          ret_holidays.each do |holiday|
+            if holiday[:date] >= from_date && holiday[:date] <= to_date
+              holidays << holiday
+            end
+          end
+
+          holidays.sort{|a, b| a[:date] <=> b[:date] }
+        end
+
+        private
+
+        attr_reader :holidays_by_month_repo,
+                    :day_of_month_calculator,
+                    :custom_methods_repo,
+                    :proc_result_cache_repo
+
+        def validate!(from_date, to_date, dates_driver, regions)
+          raise ArgumentError unless from_date
+          raise ArgumentError unless to_date
+
+          raise ArgumentError if dates_driver.nil? || dates_driver.empty?
+
+          dates_driver.each do |year, months|
+            raise ArgumentError if months.nil? || months.empty?
+          end
+
+          raise ArgumentError if regions.nil? || regions.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/holidays/use_case_factory.rb
+++ b/lib/holidays/use_case_factory.rb
@@ -2,6 +2,7 @@ require 'holidays/use_case/context/context_common'
 require 'holidays/use_case/context/between'
 require 'holidays/use_case/context/next_holiday'
 require 'holidays/use_case/context/dates_driver_builder'
+require 'holidays/use_case/context/year_holiday'
 
 module Holidays
   class UseCaseFactory
@@ -16,6 +17,15 @@ module Holidays
       end
       def next_holiday
         UseCase::Context::NextHoliday.new(
+          DefinitionFactory.holidays_by_month_repository,
+          DateCalculatorFactory.day_of_month_calculator,
+          DefinitionFactory.custom_methods_repository,
+          DefinitionFactory.proc_result_cache_repository,
+        )
+      end
+
+      def year_holiday
+        UseCase::Context::YearHoliday.new(
           DefinitionFactory.holidays_by_month_repository,
           DateCalculatorFactory.day_of_month_calculator,
           DefinitionFactory.custom_methods_repository,

--- a/test/holidays/core_extensions/test_date_time.rb
+++ b/test/holidays/core_extensions/test_date_time.rb
@@ -1,0 +1,60 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../../test_helper'
+
+require 'holidays/core_extensions/date'
+require 'holidays/core_extensions/time'
+
+class Date
+  include Holidays::CoreExtensions::Date
+end
+
+class Time 
+  include Holidays::CoreExtensions::Time
+end 
+
+class CoreExtensionDateTimeTests < Test::Unit::TestCase
+  def setup
+    @date = Date.civil(2008,1,1)
+  end
+
+  def test_change_method 
+    actual = @date.change(day: 5)
+    assert_equal Date.civil(2008,1,5), actual
+
+    actual = @date.change(year: 2016)
+    assert_equal Date.civil(2016,1,1), actual
+
+    actual = @date.change(month: 5)
+    assert_equal Date.civil(2008,5,1), actual
+
+    actual = @date.change(year: 2015, month: 5, day: 3)
+    assert_equal Date.civil(2015,5,3), actual
+  end 
+
+  def test_end_of_month_method
+    # Works for month with 31 days
+    actual = @date.end_of_month 
+    assert_equal Date.civil(2008,1,31), actual
+
+    # Works for month with 30 days
+    actual = Date.civil(2008,9,5).end_of_month
+    assert_equal Date.civil(2008,9,30), actual
+
+    # Works for leap year
+    actual = Date.civil(2016,2,1).end_of_month
+    assert_equal = Date.civil(2016,2,29), actual
+  end
+
+  def test_days_in_month_method
+    # Works for month with 31 days
+    actual = Time.days_in_month(1, 2008)
+    assert_equal 31, actual
+
+    # Works for month with 30 days
+    actual = Time.days_in_month(9, 2008)
+    assert_equal 30, actual
+
+    # Works for leap year
+    actual = Time.days_in_month(2, 2016)
+    assert_equal 29, actual
+  end    
+end 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,11 +11,16 @@ require 'mocha/test_unit'
 require 'date'
 require 'holidays'
 require 'holidays/core_extensions/date'
+require 'holidays/core_extensions/time'
 
 # Loads core extension for use in various definition tests as necessary
 class Date
   include Holidays::CoreExtensions::Date
 end
+
+class Time
+  include Holidays::CoreExtensions::Time
+end 
 
 module Holidays
   # Test region used for generating a holiday on Date.today

--- a/test/test_holidays.rb
+++ b/test/test_holidays.rb
@@ -139,10 +139,59 @@ class HolidaysTests < Test::Unit::TestCase
     end
   end
 
-  def test_any_region_holiday_year
+  def test_year_holidays
+    # Should return 10 holidays from February 23 to December 31
     holidays = Holidays.year_holidays([:ca_on], Date.civil(2016, 2, 23))
-    holidays.each {|h| puts h}
-    # assert_equal 12, holidays.length
+    assert_equal 10, holidays.length
+
+    # Must have options (Regions)
+    assert_raises ArgumentError do 
+      Holidays.year_holidays([], Date.civil(2016, 2, 23))
+    end 
+
+    # Options must be in the form of an array.  
+    assert_raises ArgumentError do 
+      Holidays.year_holidays(:ca_on, Date.civil(2016, 2, 23))
+    end 
+  end 
+
+  def test_year_holidays_with_specified_year
+    # Should return all 12 holidays for 2016 in Ontario, Canada
+    holidays = Holidays.year_holidays([:ca_on], Date.civil(2016, 1, 1))
+    assert_equal 12, holidays.length
+
+    # Should return all 12 holidays for 2016 in Australia
+    holidays = Holidays.year_holidays([:au], Date.civil(2016, 1, 1))
+    assert_equal 5, holidays.length
+  end 
+
+  def test_year_holidays_without_specified_year 
+    # Gets holidays for current year from today's date
+    holidays = Holidays.year_holidays([:ca_on])
+    assert_equal holidays.first[:date].year, Date.today.year
+  end 
+
+  def test_year_holidays_feb_29_on_non_leap_year
+    # Should throw argument error for invalid date
+    assert_raises ArgumentError do 
+      Holidays.year_holidays([:ca_on], Date.civil(2015, 2, 29))
+    end
+  end 
+
+  def test_year_holidays_random_years
+    # Should be 1 less holiday, as Family day didn't exist in Ontario in 1990
+    holidays = Holidays.year_holidays([:ca_on], Date.civil(1990, 1, 1))
+    assert_equal 11, holidays.length
+
+    # Family day still didn't exist in 2000
+    holidays = Holidays.year_holidays([:ca_on], Date.civil(2000, 1, 1))
+    assert_equal 11, holidays.length
+
+    holidays = Holidays.year_holidays([:ca_on], Date.civil(2020, 1, 1))
+    assert_equal 12, holidays.length
+
+    holidays = Holidays.year_holidays([:ca_on], Date.civil(2050, 1, 1))
+    assert_equal 12, holidays.length
   end 
 
   def test_sub_regions

--- a/test/test_holidays.rb
+++ b/test/test_holidays.rb
@@ -139,6 +139,12 @@ class HolidaysTests < Test::Unit::TestCase
     end
   end
 
+  def test_any_region_holiday_year
+    holidays = Holidays.year_holidays([:ca_on], Date.civil(2016, 2, 23))
+    holidays.each {|h| puts h}
+    # assert_equal 12, holidays.length
+  end 
+
   def test_sub_regions
     # Should return Victoria Day.
     holidays = Holidays.between(Date.civil(2008,5,1), Date.civil(2008,5,31), :ca)


### PR DESCRIPTION
I needed a way of getting a list of all the holidays for a region from a certain date to the end of the year, so I wrote it.  I used some of Rails' Date calculations in order to do this (ie. end_of_month, change).  I thought that if I needed this functionality, it may also be useful for others.