### PR TITLE
Remove Remembrance Day from certain Canadian provinces

### DIFF
--- a/definitions/ca.yaml
+++ b/definitions/ca.yaml
@@ -141,7 +141,7 @@ months:
     wday: 1
   11:
   - name: Remembrance Day
-    regions: [ca]
+    regions: [ ca_ab, ca_sk, ca_bc, ca_pe, ca_nf, ca_nt, ca_nu, ca_nb, ca_yk]
     mday: 11
   12:
   - name: Christmas Day
@@ -171,7 +171,6 @@ tests: |
      Date.civil(2008,7,1) => 'Canada Day',
      Date.civil(2008,9,1) => 'Labour Day',
      Date.civil(2008,10,13) => 'Thanksgiving',
-     Date.civil(2008,11,11) => 'Remembrance Day',
      Date.civil(2008,12,25) => 'Christmas Day',
      Date.civil(2008,12,26) => 'Boxing Day'}.each do |date, name|
       assert_equal name, (Holidays.on(date, :ca, :informal)[0] || {})[:name]
@@ -299,4 +298,20 @@ tests: |
         :ca_nb => 'New Brunswick Day' }.each do |region, name|
         assert_equal name, Holidays.on(date, region)[0][:name]
       end
+    end
+
+    # Remembrance Day in all Canadian provinces
+    # except (Nova Scotia, Manitoba, Ontario, and Quebec)
+    [
+      :ca_ab,
+      :ca_sk,
+      :ca_bc,
+      :ca_pe,
+      :ca_nf,
+      :ca_nt,
+      :ca_nu,
+      :ca_nb,
+      :ca_yk
+    ].each do |province|
+      assert_equal "Remembrance Day", Holidays.on(Date.civil(2016,11,11), province)[0][:name]
     end

--- a/lib/generated_definitions/ca.rb
+++ b/lib/generated_definitions/ca.rb
@@ -55,7 +55,7 @@ module Holidays
       9 => [{:wday => 1, :week => 1, :name => "Labour Day", :regions => [:ca]}],
       10 => [{:wday => 1, :week => 2, :name => "Thanksgiving", :regions => [:ca]},
             {:mday => 31, :type => :informal, :name => "Halloween", :regions => [:us, :ca]}],
-      11 => [{:mday => 11, :name => "Remembrance Day", :regions => [:ca]}],
+      11 => [{:mday => 11, :name => "Remembrance Day", :regions => [:ca_ab, :ca_sk, :ca_bc, :ca_pe, :ca_nf, :ca_nt, :ca_nu, :ca_nb, :ca_yk]}],
       12 => [{:mday => 25, :name => "Christmas Day", :regions => [:ca]},
             {:mday => 26, :name => "Boxing Day", :regions => [:ca]}],
       4 => [{:mday => 1, :type => :informal, :name => "April Fool's Day", :regions => [:us, :ca]},

--- a/lib/generated_definitions/north_america.rb
+++ b/lib/generated_definitions/north_america.rb
@@ -79,7 +79,7 @@ module Holidays
             {:mday => 12, :type => :informal, :name => "Día de la Raza", :regions => [:mx]},
             {:wday => 1, :week => 2, :name => "Columbus Day", :regions => [:us]},
             {:mday => 31, :type => :informal, :name => "Halloween", :regions => [:us, :ca]}],
-      11 => [{:mday => 11, :name => "Remembrance Day", :regions => [:ca]},
+      11 => [{:mday => 11, :name => "Remembrance Day", :regions => [:ca_ab, :ca_sk, :ca_bc, :ca_pe, :ca_nf, :ca_nt, :ca_nu, :ca_nb, :ca_yk]},
             {:mday => 1, :type => :informal, :name => "Todos los Santos", :regions => [:mx]},
             {:mday => 2, :type => :informal, :name => "Los Fieles Difuntos", :regions => [:mx]},
             {:wday => 1, :week => 3, :name => "Día de la Revolución", :regions => [:mx]},

--- a/test/defs/test_defs_ca.rb
+++ b/test/defs/test_defs_ca.rb
@@ -15,7 +15,6 @@ class CaDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2008,7,1) => 'Canada Day',
  Date.civil(2008,9,1) => 'Labour Day',
  Date.civil(2008,10,13) => 'Thanksgiving',
- Date.civil(2008,11,11) => 'Remembrance Day',
  Date.civil(2008,12,25) => 'Christmas Day',
  Date.civil(2008,12,26) => 'Boxing Day'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :ca, :informal)[0] || {})[:name]
@@ -143,6 +142,22 @@ end
     :ca_nb => 'New Brunswick Day' }.each do |region, name|
     assert_equal name, Holidays.on(date, region)[0][:name]
   end
+end
+
+# Remembrance Day in all Canadian provinces
+# except (Nova Scotia, Manitoba, Ontario, and Quebec)
+[
+  :ca_ab,
+  :ca_sk,
+  :ca_bc,
+  :ca_pe,
+  :ca_nf,
+  :ca_nt,
+  :ca_nu,
+  :ca_nb,
+  :ca_yk
+].each do |province|
+  assert_equal "Remembrance Day", Holidays.on(Date.civil(2016,11,11), province)[0][:name]
 end
 
 

--- a/test/defs/test_defs_north_america.rb
+++ b/test/defs/test_defs_north_america.rb
@@ -15,7 +15,6 @@ class North_americaDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2008,7,1) => 'Canada Day',
  Date.civil(2008,9,1) => 'Labour Day',
  Date.civil(2008,10,13) => 'Thanksgiving',
- Date.civil(2008,11,11) => 'Remembrance Day',
  Date.civil(2008,12,25) => 'Christmas Day',
  Date.civil(2008,12,26) => 'Boxing Day'}.each do |date, name|
   assert_equal name, (Holidays.on(date, :ca, :informal)[0] || {})[:name]
@@ -143,6 +142,22 @@ end
     :ca_nb => 'New Brunswick Day' }.each do |region, name|
     assert_equal name, Holidays.on(date, region)[0][:name]
   end
+end
+
+# Remembrance Day in all Canadian provinces
+# except (Nova Scotia, Manitoba, Ontario, and Quebec)
+[
+  :ca_ab,
+  :ca_sk,
+  :ca_bc,
+  :ca_pe,
+  :ca_nf,
+  :ca_nt,
+  :ca_nu,
+  :ca_nb,
+  :ca_yk
+].each do |province|
+  assert_equal "Remembrance Day", Holidays.on(Date.civil(2016,11,11), province)[0][:name]
 end
 
 

--- a/test/integration/test_holidays.rb
+++ b/test/integration/test_holidays.rb
@@ -135,9 +135,9 @@ class HolidaysTests < Test::Unit::TestCase
   end
 
   def test_year_holidays
-    # Should return 10 holidays from February 23 to December 31
+    # Should return 9 holidays from February 23 to December 31
     holidays = Holidays.year_holidays([:ca_on], Date.civil(2016, 2, 23))
-    assert_equal 10, holidays.length
+    assert_equal 9, holidays.length
 
     # Must have options (Regions)
     assert_raises ArgumentError do
@@ -151,11 +151,11 @@ class HolidaysTests < Test::Unit::TestCase
   end
 
   def test_year_holidays_with_specified_year
-    # Should return all 12 holidays for 2016 in Ontario, Canada
+    # Should return all 11 holidays for 2016 in Ontario, Canada
     holidays = Holidays.year_holidays([:ca_on], Date.civil(2016, 1, 1))
-    assert_equal 12, holidays.length
+    assert_equal 11, holidays.length
 
-    # Should return all 12 holidays for 2016 in Australia
+    # Should return all 5 holidays for 2016 in Australia
     holidays = Holidays.year_holidays([:au], Date.civil(2016, 1, 1))
     assert_equal 5, holidays.length
   end
@@ -191,17 +191,17 @@ class HolidaysTests < Test::Unit::TestCase
   def test_year_holidays_random_years
     # Should be 1 less holiday, as Family day didn't exist in Ontario in 1990
     holidays = Holidays.year_holidays([:ca_on], Date.civil(1990, 1, 1))
-    assert_equal 11, holidays.length
+    assert_equal 10, holidays.length
 
     # Family day still didn't exist in 2000
     holidays = Holidays.year_holidays([:ca_on], Date.civil(2000, 1, 1))
-    assert_equal 11, holidays.length
+    assert_equal 10, holidays.length
 
     holidays = Holidays.year_holidays([:ca_on], Date.civil(2020, 1, 1))
-    assert_equal 12, holidays.length
+    assert_equal 11, holidays.length
 
     holidays = Holidays.year_holidays([:ca_on], Date.civil(2050, 1, 1))
-    assert_equal 12, holidays.length
+    assert_equal 11, holidays.length
 
     holidays = Holidays.year_holidays([:jp], Date.civil(2070, 1, 1))
     assert_equal 18, holidays.length


### PR DESCRIPTION
Hi, 

we noticed that Remembrance Day is defined wrong for Canada.

it should be 

> In Canada, Remembrance Day is a statutory holiday in all three territories and in six of the ten provinces (Nova Scotia, Manitoba, Ontario, and Quebec being the exceptions).

as defined here - https://en.wikipedia.org/wiki/Remembrance_Day

Thanks for the gem!