### PR TITLE
Add jruby's debug option for test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+env: JRUBY_OPTS=--debug 
 language: ruby
 
 cache:


### PR DESCRIPTION
Jruby 9.0.X tests are all fine through not calculated coverage.
Maybe ,this is jruby 9.0.X issue(see https://github.com/jruby/jruby/issues/1981).