### PR TITLE
Not 'return nil' in custom methods and use year_range feature.

### DIFF
--- a/definitions/jp.yaml
+++ b/definitions/jp.yaml
@@ -119,6 +119,8 @@ months:
     function: jp_respect_for_aged_holiday_substitute(year)
   - name: 国民の休日
     regions: [jp]
+    year_ranges:
+      - after: 2003
     function: jp_citizens_holiday(year)
   - name: 秋分の日
     regions: [jp]
@@ -218,7 +220,6 @@ methods:
   jp_citizens_holiday:
     arguments: year
     source: |
-      year < 2003 and return nil
       ncd = Holidays::Factory::Definition.custom_methods_repository.find("jp_national_culture_day(year)").call(year)
       if ncd.wday == 3
         ncd - 1
@@ -228,7 +229,6 @@ methods:
   jp_mountain_holiday:
     arguments: year
     source: |
-      return nil if year < 2016
       Date.civil(year, 8, 11)
   jp_mountain_holiday_substitute:
     arguments: year
@@ -314,3 +314,8 @@ tests: |
 
   # before 2016, there is no mountain holiday.
   assert_nil Holidays.on(Date.civil(2015,8,11), :jp)[0]
+
+  # before 2003, there is no citizens holiday.
+  # [note] citizens holiday requires that jp_national_culture_day is wednesday.
+  #        Before 2003, the closest past year that mathches above condition is 1998.
+  assert_nil Holidays.on(Date.civil(1998,9,22), :jp)[0]

--- a/holidays.gemspec
+++ b/holidays.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '~> 2.0'
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'coveralls', '= 0.8.11'
+  gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'mocha', '~>1.0'
   gem.add_development_dependency 'pry', '~>0.10'

--- a/lib/generated_definitions/jp.rb
+++ b/lib/generated_definitions/jp.rb
@@ -40,7 +40,7 @@ module Holidays
             {:function => "jp_mountain_holiday_substitute(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2016}],:name => "振替休日", :regions => [:jp]}],
       9 => [{:wday => 1, :week => 3, :name => "敬老の日", :regions => [:jp]},
             {:function => "jp_respect_for_aged_holiday_substitute(year)", :function_arguments => [:year], :name => "振替休日", :regions => [:jp]},
-            {:function => "jp_citizens_holiday(year)", :function_arguments => [:year], :name => "国民の休日", :regions => [:jp]},
+            {:function => "jp_citizens_holiday(year)", :function_arguments => [:year],  :year_ranges => [{:after => 2003}],:name => "国民の休日", :regions => [:jp]},
             {:function => "jp_national_culture_day(year)", :function_arguments => [:year], :name => "秋分の日", :regions => [:jp]},
             {:function => "jp_national_culture_day_substitute(year)", :function_arguments => [:year], :name => "振替休日", :regions => [:jp]}],
       10 => [{:wday => 1, :week => 2, :name => "体育の日", :regions => [:jp]},
@@ -113,7 +113,6 @@ Holidays::Factory::Definition.custom_methods_repository.find("jp_substitute_holi
 },
 
 "jp_citizens_holiday(year)" => Proc.new { |year|
-year < 2003 and return nil
 ncd = Holidays::Factory::Definition.custom_methods_repository.find("jp_national_culture_day(year)").call(year)
 if ncd.wday == 3
   ncd - 1
@@ -123,7 +122,6 @@ end
 },
 
 "jp_mountain_holiday(year)" => Proc.new { |year|
-return nil if year < 2016
 Date.civil(year, 8, 11)
 },
 

--- a/test/defs/test_defs_jp.rb
+++ b/test/defs/test_defs_jp.rb
@@ -69,5 +69,9 @@ end
 # before 2016, there is no mountain holiday.
 assert_nil Holidays.on(Date.civil(2015,8,11), :jp)[0]
 
+# before 2003, there is no citizens holiday.
+# [note] citizens holiday requires that jp_national_culture_day is wednesday.
+#        Before 2003, the closest past year that mathches above condition is 1998.
+assert_nil Holidays.on(Date.civil(1998,9,22), :jp)[0]
   end
 end


### PR DESCRIPTION
Fixes [issue-225
](https://github.com/holidays/holidays/issues/225).

I have investigated whether other definitions use 'return nil' in custom methods .
There was nothing 'return nil' .

@ptrimble Can you please check this PR?