### PR TITLE
fix load_error when 'test_region' is executed.

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require 'coverage_report'
+require File.dirname(__FILE__) + '/coverage_report'
 
 $:.unshift(File.expand_path(File.dirname(__FILE__) + '../../lib/'))
 


### PR DESCRIPTION
If i test local's definition , i execute below command.
`REGION=jp make test_tregion`

But 'coverger_report' load error occurred.
Please check example below.

```
ttwo32 $ REGION=jp make test_region 
bundle exec rake test_region jp
bundle exec ruby test/defs/test_defs_jp.rb
/Users/ttwo32/work/holidays/test/test_helper.rb:1:in `require': cannot load such file -- coverage_report (LoadError)
	from /Users/ttwo32/work/holidays/test/test_helper.rb:1:in `<top (required)>'
	from test/defs/test_defs_jp.rb:2:in `require'
	from test/defs/test_defs_jp.rb:2:in `<main>'
rake aborted
```


