### PR TITLE
Fix holidays caching feature

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -29,7 +29,7 @@ module Holidays
     end
 
     def on(date, *options)
-      between(date, date, options)
+      between(date, date, *options)
     end
 
     def between(start_date, end_date, *options)

--- a/lib/holidays/definition/repository/cache.rb
+++ b/lib/holidays/definition/repository/cache.rb
@@ -6,14 +6,14 @@ module Holidays
           reset!
         end
 
-        def cache_between(start_date, end_date, cache_data, *options)
+        def cache_between(start_date, end_date, cache_data, options)
           raise ArgumentError unless cache_data
 
           @cache_range[options] = start_date..end_date
           @cache[options] = cache_data
         end
 
-        def find(start_date, end_date, *options)
+        def find(start_date, end_date, options)
           if range = @cache_range[options]
             if range.begin <= start_date && range.end >= end_date
               return @cache[options].select do |holiday|

--- a/test/integration/test_holidays.rb
+++ b/test/integration/test_holidays.rb
@@ -269,17 +269,17 @@ class HolidaysTests < Test::Unit::TestCase
     cache_data = Holidays.between(start_date, end_date, :ca, :informal)
     options = [:ca, :informal]
 
-    Holidays::Factory::Definition.cache_repository.expects(:cache_between).with(start_date, end_date, cache_data, options)
-
     Holidays.cache_between(Date.civil(2008,3,21), Date.civil(2008,3,25), :ca, :informal)
-
-    # Test that cache has been set and it returns the same as before
-    assert_equal 1, Holidays.on(Date.civil(2008, 3, 21), :ca, :informal).length
-    assert_equal 1, Holidays.on(Date.civil(2008, 3, 24), :ca, :informal).length
 
     # Test that correct results are returned outside the cache range, and with no caching
     assert_equal 1, Holidays.on(Date.civil(2035,1,1), :ca, :informal).length
     assert_equal 1, Holidays.on(Date.civil(2035,1,1), :us).length
+
+    Holidays::Factory::Finder.expects(:between).never # Make sure cache is hit for two next call
+
+    # Test that cache has been set and it returns the same as before
+    assert_equal 1, Holidays.on(Date.civil(2008, 3, 21), :ca, :informal).length
+    assert_equal 1, Holidays.on(Date.civil(2008, 3, 24), :ca, :informal).length
   end
 
   def test_load_all


### PR DESCRIPTION
This PR fixes the caching feature of the gem. The description of the issue can be found here: https://github.com/holidays/holidays/issues/241#issuecomment-262653341.

Interesting to note it that the tests for caching never worked, partly due to the call to `Holidays::Factory::Definition.cache_repository.expects(:cache_between).with(start_date, end_date, cache_data, options)` completely stubbed call to `cache_between`, which means that the cache has never been setup in the first place.

Here are some results I've been having when benchmarking performance for calls to `Holidays.on(Date.today, :us, :observed)}`.

| Cached regions                | Time (s) for 10000 lookups (1 year cache) |
|-------------------------------|--------------------------------------------------|
| None                          | 4.72                                             |
| :us, :observed                | 0.08                                             |

@ptrimble 