### PR TITLE
Add methods to calculate lunar dates

### DIFF
--- a/lib/holidays/date_calculator/lunar_date.rb
+++ b/lib/holidays/date_calculator/lunar_date.rb
@@ -25,7 +25,7 @@ module Holidays
           days += lunardays_for_type(year_info[year_diff][month])[1]
         end
 
-        solar_date = SOLAR_START_DATE + days
+        SOLAR_START_DATE + days
       end
 
       def to_s

--- a/lib/holidays/date_calculator/lunar_date.rb
+++ b/lib/holidays/date_calculator/lunar_date.rb
@@ -21,19 +21,11 @@ module Holidays
 
         days += (day - 1)
 
-        if is_leap_month && year_info[year_diff][month] > 2
-          days += lunardays_for_type(year_info[year_diff][month])[1]
-        end
-
         SOLAR_START_DATE + days
       end
 
       def to_s
         format('%4d%02d%02d', year, month, day)
-      end
-
-      def inspect
-        to_s
       end
 
       private
@@ -207,64 +199,11 @@ module Holidays
 
       SOLAR_START_DATE = Date.new(1900, 1, 31).freeze
 
-      def initialize(year, month, day, is_leap_month = false)
-        self.year = year
-        self.month = month
-        self.day = day
-        self.is_leap_month = is_leap_month
-      end
-
       class << self
         private
 
         def lunardays_for_type(month_type)
           LUNARDAYS_FOR_MONTHTYPE[month_type]
-        end
-
-        def get_days(solar_date)
-          (solar_date - SOLAR_START_DATE).to_i
-        end
-
-        def in_this_days?(days, left_days)
-          (days - left_days) < 0
-        end
-
-        def lunar_from_days(days, calendar_symbol)
-          start_year = 1900
-          target_month = 0
-          is_leap_month = false
-          matched = false
-          year_info = CALENDAR_YEAR_INFO_MAP[calendar_symbol]
-
-          MAX_YEAR_NUMBER.times do |year_idx|
-            year_days = year_info[year_idx][0]
-            if in_this_days?(days, year_days)
-              12.times do |month_idx|
-                total, normal, _leap = lunardays_for_type(year_info[year_idx][month_idx + 1])
-                if in_this_days?(days, total)
-                  unless in_this_days?(days, normal)
-                    days -= normal
-                    is_leap_month = true
-                  end
-
-                  matched = true
-                  break
-                end
-
-                days -= total
-                target_month += 1
-              end
-            end
-
-            break if matched
-
-            days -= year_days
-            start_year += 1
-          end
-
-          lunar_date = new(start_year, target_month + 1, days + 1, is_leap_month)
-
-          lunar_date
         end
       end
     end

--- a/lib/holidays/date_calculator/lunar_date.rb
+++ b/lib/holidays/date_calculator/lunar_date.rb
@@ -1,0 +1,272 @@
+module Holidays
+  module DateCalculator
+    # Copied from https://github.com/sunsidew/ruby_lunardate
+    # Graciously allowed by JeeWoong Yang (https://github.com/sunsidew)
+    class LunarDate
+      attr_accessor :year, :month, :day, :is_leap_month
+
+      def self.to_solar(year, month, day, is_leap_month = false, calendar_symbol = :ko)
+        days = 0
+        year_diff = year - 1900
+        year_info = CALENDAR_YEAR_INFO_MAP[calendar_symbol]
+
+        year_diff.times do |year_idx|
+          days += year_info[year_idx][0]
+        end
+
+        (month - 1).times do |month_idx|
+          total, _normal, _leap = lunardays_for_type(year_info[year_diff][month_idx + 1])
+          days += total
+        end
+
+        days += (day - 1)
+
+        if is_leap_month && year_info[year_diff][month] > 2
+          days += lunardays_for_type(year_info[year_diff][month])[1]
+        end
+
+        solar_date = SOLAR_START_DATE + days
+      end
+
+      def to_s
+        format('%4d%02d%02d', year, month, day)
+      end
+
+      def inspect
+        to_s
+      end
+
+      private
+
+      KOREAN_LUNAR_YEAR_INFO = [
+        [384, 1, 2, 1, 1, 2, 1, 2, 4, 2, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [355, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2].freeze,
+        [383, 1, 2, 1, 2, 3, 2, 1, 1, 2, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 2, 1, 1, 2, 1, 1, 2, 2, 1].freeze,
+        [355, 2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [384, 1, 2, 2, 5, 1, 2, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 2, 1, 2, 1, 2, 2, 1, 2].freeze,
+        [384, 1, 4, 1, 2, 1, 2, 1, 2, 2, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [384, 2, 1, 2, 1, 1, 4, 1, 2, 2, 1, 2, 2].freeze,
+        [354, 2, 1, 2, 1, 1, 2, 1, 1, 2, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [384, 2, 2, 1, 2, 4, 1, 2, 1, 2, 1, 1, 2].freeze,
+        [355, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1].freeze,
+        [384, 2, 3, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 1, 2].freeze,
+        [384, 1, 2, 1, 1, 2, 1, 4, 2, 2, 1, 2, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 1, 2, 2, 1, 2, 2].freeze,
+        [354, 2, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2].freeze,
+        [384, 2, 1, 2, 2, 3, 2, 1, 1, 2, 1, 2, 2].freeze,
+        [354, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 1, 2].freeze,
+        [354, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1, 1].freeze,
+        [385, 2, 1, 2, 4, 2, 1, 2, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2].freeze,
+        [384, 1, 4, 1, 2, 1, 1, 2, 2, 1, 2, 2, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2, 2].freeze,
+        [383, 1, 2, 2, 1, 1, 4, 1, 2, 1, 2, 2, 1].freeze,
+        [354, 2, 2, 2, 1, 1, 2, 1, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 2, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [384, 1, 2, 2, 1, 6, 1, 2, 1, 2, 1, 1, 2].freeze,
+        [355, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1].freeze,
+        [384, 2, 1, 5, 1, 2, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [354, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [384, 2, 2, 1, 1, 2, 1, 5, 1, 2, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 1, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1].freeze,
+        [384, 2, 2, 1, 2, 2, 5, 1, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1, 1, 2].freeze,
+        [355, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2].freeze,
+        [384, 1, 1, 2, 5, 1, 2, 1, 2, 2, 1, 2, 2].freeze,
+        [354, 1, 1, 2, 1, 1, 2, 1, 2, 2, 2, 1, 2].freeze,
+        [354, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2].freeze,
+        [384, 2, 4, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2].freeze,
+        [354, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [384, 2, 2, 1, 2, 1, 2, 3, 2, 1, 2, 1, 2].freeze,
+        [354, 2, 1, 2, 2, 1, 2, 1, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2].freeze,
+        [384, 1, 2, 1, 2, 5, 2, 1, 2, 1, 2, 1, 2].freeze,
+        [355, 1, 2, 1, 1, 2, 2, 1, 2, 2, 1, 2, 2].freeze,
+        [354, 1, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2].freeze,
+        [384, 2, 1, 5, 1, 1, 2, 1, 2, 1, 2, 2, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2].freeze,
+        [384, 2, 1, 2, 1, 2, 1, 1, 4, 2, 1, 2, 2].freeze,
+        [354, 1, 2, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1].freeze,
+        [384, 2, 1, 2, 1, 2, 4, 2, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2, 1].freeze,
+        [384, 2, 1, 2, 3, 2, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [355, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 1, 2, 1, 1, 2, 2, 2].freeze,
+        [383, 1, 2, 4, 2, 1, 1, 2, 1, 1, 2, 2, 1].freeze,
+        [355, 2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [384, 1, 2, 2, 1, 2, 1, 4, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 2, 1, 2, 1, 2, 2, 1, 2].freeze,
+        [384, 1, 2, 1, 1, 4, 2, 1, 2, 2, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [354, 2, 1, 2, 1, 1, 2, 1, 1, 2, 2, 2, 1].freeze,
+        [384, 2, 2, 1, 4, 1, 2, 1, 1, 2, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [384, 2, 2, 1, 2, 1, 2, 1, 4, 2, 1, 1, 2].freeze,
+        [354, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 1].freeze,
+        [355, 2, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1].freeze,
+        [384, 2, 1, 1, 2, 1, 6, 1, 2, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 1, 2, 2, 1, 2, 2].freeze,
+        [384, 2, 1, 2, 3, 2, 1, 1, 2, 2, 1, 2, 2].freeze,
+        [354, 2, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2].freeze,
+        [384, 2, 1, 2, 2, 1, 1, 2, 1, 1, 4, 2, 2].freeze,
+        [354, 1, 2, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2, 1, 1].freeze,
+        [385, 2, 1, 2, 2, 1, 4, 2, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2].freeze,
+        [384, 1, 2, 1, 1, 4, 1, 2, 2, 1, 2, 2, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2, 2].freeze,
+        [354, 1, 2, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2].freeze,
+        [383, 1, 2, 4, 2, 1, 2, 1, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 2, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [384, 1, 2, 2, 1, 2, 2, 1, 4, 2, 1, 1, 2].freeze,
+        [355, 1, 2, 1, 2, 2, 1, 2, 1, 2, 2, 1, 2].freeze,
+        [354, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1].freeze,
+        [384, 2, 1, 1, 2, 3, 2, 2, 1, 2, 2, 2, 1].freeze,
+        [354, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [354, 2, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2, 1].freeze,
+        [384, 2, 2, 2, 3, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 2, 1, 2, 2, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [384, 1, 4, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 1].freeze,
+        [385, 2, 1, 2, 1, 2, 1, 4, 2, 2, 1, 2, 2].freeze,
+        [354, 1, 1, 2, 1, 1, 2, 1, 2, 2, 2, 1, 2].freeze,
+        [354, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2].freeze,
+        [384, 2, 2, 1, 1, 4, 1, 2, 1, 2, 1, 2, 2].freeze,
+        [354, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 2, 1, 2, 2, 1, 2, 1, 1, 2, 1, 2, 1].freeze,
+        [384, 2, 1, 6, 2, 1, 2, 1, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2].freeze,
+        [384, 1, 2, 1, 2, 1, 2, 1, 2, 4, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 2, 2, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2].freeze,
+        [384, 1, 2, 1, 2, 3, 2, 1, 2, 1, 2, 2, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2].freeze,
+        [354, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [384, 2, 1, 2, 4, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2].freeze,
+        [384, 1, 4, 2, 1, 2, 1, 2, 2, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2, 1].freeze,
+        [384, 2, 1, 2, 1, 1, 4, 2, 1, 2, 2, 2, 1].freeze,
+        [355, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2].freeze,
+        [354, 1, 2, 1, 2, 1, 1, 2, 1, 1, 2, 2, 2].freeze,
+        [383, 1, 2, 2, 1, 4, 1, 2, 1, 1, 2, 2, 1].freeze,
+        [355, 2, 2, 1, 2, 2, 1, 1, 2, 1, 1, 2, 2].freeze,
+        [354, 1, 2, 1, 2, 2, 1, 2, 1, 2, 1, 2, 1].freeze,
+        [384, 2, 1, 4, 2, 1, 2, 2, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2].freeze,
+        [384, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 4, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 1].freeze,
+        [354, 2, 1, 2, 1, 1, 2, 1, 1, 2, 2, 1, 2].freeze,
+        [384, 2, 2, 1, 2, 1, 5, 1, 1, 2, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [354, 2, 2, 1, 2, 1, 2, 1, 2, 1, 1, 2, 1].freeze,
+        [384, 2, 2, 1, 2, 4, 2, 1, 2, 1, 2, 1, 1].freeze,
+        [355, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2, 1].freeze,
+        [355, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2].freeze,
+        [384, 1, 4, 1, 2, 1, 2, 1, 2, 2, 2, 1, 2].freeze,
+        [354, 1, 2, 1, 1, 2, 1, 1, 2, 2, 1, 2, 2].freeze,
+        [384, 2, 1, 2, 1, 1, 2, 3, 2, 1, 2, 2, 2].freeze,
+        [354, 2, 1, 2, 1, 1, 2, 1, 1, 2, 1, 2, 2].freeze,
+        [354, 2, 1, 2, 2, 1, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [384, 2, 1, 2, 2, 5, 1, 2, 1, 1, 2, 1, 2].freeze,
+        [354, 1, 2, 2, 1, 2, 2, 1, 2, 1, 2, 1, 1].freeze,
+        [355, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 2, 1].freeze
+      ].freeze
+
+      MAX_YEAR_NUMBER = 150
+      CALENDAR_YEAR_INFO_MAP = {
+        ko: KOREAN_LUNAR_YEAR_INFO
+      }.freeze
+
+      LUNARDAYS_FOR_MONTHTYPE = {
+        1 => [29, 29, 0],
+        2 => [30, 30, 0],
+        3 => [58, 29, 29],
+        4 => [59, 30, 29],
+        5 => [59, 29, 30],
+        6 => [60, 30, 30]
+      }.freeze
+
+      SOLAR_START_DATE = Date.new(1900, 1, 31).freeze
+
+      def initialize(year, month, day, is_leap_month = false)
+        self.year = year
+        self.month = month
+        self.day = day
+        self.is_leap_month = is_leap_month
+      end
+
+      class << self
+        private
+
+        def lunardays_for_type(month_type)
+          LUNARDAYS_FOR_MONTHTYPE[month_type]
+        end
+
+        def get_days(solar_date)
+          (solar_date - SOLAR_START_DATE).to_i
+        end
+
+        def in_this_days?(days, left_days)
+          (days - left_days) < 0
+        end
+
+        def lunar_from_days(days, calendar_symbol)
+          start_year = 1900
+          target_month = 0
+          is_leap_month = false
+          matched = false
+          year_info = CALENDAR_YEAR_INFO_MAP[calendar_symbol]
+
+          MAX_YEAR_NUMBER.times do |year_idx|
+            year_days = year_info[year_idx][0]
+            if in_this_days?(days, year_days)
+              12.times do |month_idx|
+                total, normal, _leap = lunardays_for_type(year_info[year_idx][month_idx + 1])
+                if in_this_days?(days, total)
+                  unless in_this_days?(days, normal)
+                    days -= normal
+                    is_leap_month = true
+                  end
+
+                  matched = true
+                  break
+                end
+
+                days -= total
+                target_month += 1
+              end
+            end
+
+            break if matched
+
+            days -= year_days
+            start_year += 1
+          end
+
+          lunar_date = new(start_year, target_month + 1, days + 1, is_leap_month)
+
+          lunar_date
+        end
+      end
+    end
+  end 
+end

--- a/lib/holidays/date_calculator/lunar_date.rb
+++ b/lib/holidays/date_calculator/lunar_date.rb
@@ -5,7 +5,7 @@ module Holidays
     class LunarDate
       attr_accessor :year, :month, :day, :is_leap_month
 
-      def self.to_solar(year, month, day, is_leap_month = false, calendar_symbol = :ko)
+      def to_solar(year, month, day, is_leap_month = false, calendar_symbol = :ko)
         days = 0
         year_diff = year - 1900
         year_info = CALENDAR_YEAR_INFO_MAP[calendar_symbol]
@@ -24,6 +24,10 @@ module Holidays
         SOLAR_START_DATE + days
       end
 
+      def lunardays_for_type(month_type)
+        LUNARDAYS_FOR_MONTHTYPE[month_type]
+      end
+      
       def to_s
         format('%4d%02d%02d', year, month, day)
       end
@@ -198,14 +202,6 @@ module Holidays
       }.freeze
 
       SOLAR_START_DATE = Date.new(1900, 1, 31).freeze
-
-      class << self
-        private
-
-        def lunardays_for_type(month_type)
-          LUNARDAYS_FOR_MONTHTYPE[month_type]
-        end
-      end
     end
   end 
 end

--- a/lib/holidays/factory/date_calculator.rb
+++ b/lib/holidays/factory/date_calculator.rb
@@ -1,6 +1,7 @@
 require 'holidays/date_calculator/easter'
 require 'holidays/date_calculator/weekend_modifier'
 require 'holidays/date_calculator/day_of_month'
+require 'holidays/date_calculator/lunar_date'
 
 module Holidays
   module Factory
@@ -24,6 +25,10 @@ module Holidays
       end
 
       class << self
+        def lunar_date 
+          Holidays::DateCalculator::LunarDate
+        end
+
         def weekend_modifier
           Holidays::DateCalculator::WeekendModifier.new
         end

--- a/lib/holidays/factory/date_calculator.rb
+++ b/lib/holidays/factory/date_calculator.rb
@@ -26,7 +26,7 @@ module Holidays
 
       class << self
         def lunar_date 
-          Holidays::DateCalculator::LunarDate
+          Holidays::DateCalculator::LunarDate.new
         end
 
         def weekend_modifier

--- a/lib/holidays/load_all_definitions.rb
+++ b/lib/holidays/load_all_definitions.rb
@@ -20,6 +20,7 @@ module Holidays
           "calculate_day_of_month(year, month, day, wday)" => day_of_month_calculator.method(:call).to_proc,
           "to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday(year)" => weekend_modifier.method(:to_weekday_if_boxing_weekend_from_year_or_to_tuesday_if_monday).to_proc,
           "to_tuesday_if_sunday_or_monday_if_saturday(date)" => weekend_modifier.method(:to_tuesday_if_sunday_or_monday_if_saturday).to_proc,
+          "lunar_to_solar(year, month, day)" => lunar_date.method(:to_solar).to_proc, 
         }
 
         Factory::Definition.custom_methods_repository.add(global_methods)
@@ -41,6 +42,10 @@ module Holidays
 
       def day_of_month_calculator
         Factory::DateCalculator.day_of_month_calculator
+      end
+      
+      def lunar_date
+        Factory::DateCalculator.lunar_date
       end
     end
   end

--- a/test/holidays/date_calculator/test_lunar_date.rb
+++ b/test/holidays/date_calculator/test_lunar_date.rb
@@ -57,6 +57,4 @@ class LunarHolidaysCalculatorTests < Test::Unit::TestCase
     assert_equal '2022-09-10', @subject.to_solar(2022,8,15).to_s
     assert_equal '2025-10-06', @subject.to_solar(2025,8,15).to_s
   end
-  
-
 end

--- a/test/holidays/date_calculator/test_lunar_date.rb
+++ b/test/holidays/date_calculator/test_lunar_date.rb
@@ -4,7 +4,7 @@ require 'holidays/date_calculator/lunar_date.rb'
 
 class LunarHolidaysCalculatorTests < Test::Unit::TestCase
   def setup
-    @subject = Holidays::DateCalculator::LunarDate
+    @subject = Holidays::DateCalculator::LunarDate.new
   end
 
   def test_korean_new_year_returns_expected_results

--- a/test/holidays/date_calculator/test_lunar_date.rb
+++ b/test/holidays/date_calculator/test_lunar_date.rb
@@ -1,0 +1,62 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../../test_helper'
+
+require 'holidays/date_calculator/lunar_date.rb'
+
+class LunarHolidaysCalculatorTests < Test::Unit::TestCase
+  def setup
+    @subject = Holidays::DateCalculator::LunarDate
+  end
+
+  def test_korean_new_year_returns_expected_results
+    assert_equal '1994-02-10', @subject.to_solar(1994,1,1).to_s
+    assert_equal '1995-01-31', @subject.to_solar(1995,1,1).to_s
+    assert_equal '1999-02-16', @subject.to_solar(1999,1,1).to_s
+    assert_equal '2000-02-05', @subject.to_solar(2000,1,1).to_s
+    assert_equal '2001-01-24', @subject.to_solar(2001,1,1).to_s
+    assert_equal '2002-02-12', @subject.to_solar(2002,1,1).to_s
+    assert_equal '2008-02-07', @subject.to_solar(2008,1,1).to_s
+    assert_equal '2009-01-26', @subject.to_solar(2009,1,1).to_s
+    assert_equal '2010-02-14', @subject.to_solar(2010,1,1).to_s
+    assert_equal '2014-01-31', @subject.to_solar(2014,1,1).to_s
+    assert_equal '2017-01-28', @subject.to_solar(2017,1,1).to_s
+    assert_equal '2020-01-25', @subject.to_solar(2020,1,1).to_s
+    assert_equal '2022-02-01', @subject.to_solar(2022,1,1).to_s
+    assert_equal '2025-01-29', @subject.to_solar(2025,1,1).to_s
+  end
+
+  def test_buddahs_birthday_returns_expected_results
+    assert_equal '1994-05-18', @subject.to_solar(1994,4,8).to_s
+    assert_equal '1995-05-07', @subject.to_solar(1995,4,8).to_s
+    assert_equal '1999-05-22', @subject.to_solar(1999,4,8).to_s
+    assert_equal '2000-05-11', @subject.to_solar(2000,4,8).to_s
+    assert_equal '2001-05-01', @subject.to_solar(2001,4,8).to_s
+    assert_equal '2002-05-19', @subject.to_solar(2002,4,8).to_s
+    assert_equal '2008-05-12', @subject.to_solar(2008,4,8).to_s
+    assert_equal '2009-05-02', @subject.to_solar(2009,4,8).to_s
+    assert_equal '2010-05-21', @subject.to_solar(2010,4,8).to_s
+    assert_equal '2014-05-06', @subject.to_solar(2014,4,8).to_s
+    assert_equal '2017-05-03', @subject.to_solar(2017,4,8).to_s
+    assert_equal '2020-04-30', @subject.to_solar(2020,4,8).to_s
+    assert_equal '2022-05-08', @subject.to_solar(2022,4,8).to_s
+    assert_equal '2025-05-05', @subject.to_solar(2025,4,8).to_s
+  end
+
+  def test_korean_thanksgiving_returns_expected_results
+    assert_equal '1994-09-20', @subject.to_solar(1994,8,15).to_s
+    assert_equal '1995-09-09', @subject.to_solar(1995,8,15).to_s
+    assert_equal '1999-09-24', @subject.to_solar(1999,8,15).to_s
+    assert_equal '2000-09-12', @subject.to_solar(2000,8,15).to_s
+    assert_equal '2001-10-01', @subject.to_solar(2001,8,15).to_s
+    assert_equal '2002-09-21', @subject.to_solar(2002,8,15).to_s
+    assert_equal '2008-09-14', @subject.to_solar(2008,8,15).to_s
+    assert_equal '2009-10-03', @subject.to_solar(2009,8,15).to_s
+    assert_equal '2010-09-22', @subject.to_solar(2010,8,15).to_s
+    assert_equal '2014-09-08', @subject.to_solar(2014,8,15).to_s
+    assert_equal '2017-10-04', @subject.to_solar(2017,8,15).to_s
+    assert_equal '2020-10-01', @subject.to_solar(2020,8,15).to_s
+    assert_equal '2022-09-10', @subject.to_solar(2022,8,15).to_s
+    assert_equal '2025-10-06', @subject.to_solar(2025,8,15).to_s
+  end
+  
+
+end

--- a/test/holidays/factory/test_date_calculator.rb
+++ b/test/holidays/factory/test_date_calculator.rb
@@ -26,7 +26,7 @@ class DateCalculatorFactoryTests < Test::Unit::TestCase
   end
 
   def test_lunar_date
-    # Holidays::DateCalculator::LunarDate is not instantiated by lunar_date
+    assert @subject.lunar_date.is_a?(Holidays::DateCalculator::LunarDate)
     assert @subject.lunar_date.respond_to?('to_solar')
   end
 end

--- a/test/holidays/factory/test_date_calculator.rb
+++ b/test/holidays/factory/test_date_calculator.rb
@@ -24,4 +24,9 @@ class DateCalculatorFactoryTests < Test::Unit::TestCase
     @subject = @subject::Easter::Julian
     assert @subject.easter_calculator.is_a?(Holidays::DateCalculator::Easter::Julian)
   end
+
+  def test_lunar_date
+    # Holidays::DateCalculator::LunarDate is not instantiated by lunar_date
+    assert @subject.lunar_date.respond_to?('to_solar')
+  end
 end


### PR DESCRIPTION
Further to my [previous comment](https://github.com/holidays/holidays/pull/227#issuecomment-249375231) upon submitting definitions for the Republic of Korea, I've asked the author of the [ruby_lunardate](https://github.com/sunsidew/ruby_lunardate) library and he's agreed to letting the holidays gem use his library.  

I've done the work of adding the library into holidays here.  I'm also submitting a PR to the definitions repo to update the definitions for the Republic of Korea to use these new methods.  
