### PR TITLE
Make the 5.0.0 upgrade less painful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,11 @@
 
 * Remove support for jruby 1.7 (this is the main reason for the major semver bump)
 * Remove support for ruby 2.0 (since it is no longer being supported by the core ruby team)
-* Add back the lazy loading of regions (this was removed in the 4.0.0 bump) instead of loading upon require (this should have 
+* Add back the lazy loading of regions (this was removed in the 4.0.0 bump) instead of loading upon require (this should have
   no outward repercussions for users)
 * Move definitions into their own repository and add as submodule. This will allow for more flexibility for tools written
   in other languages.
+* Rename `DateCalculatorFactory` to `Factory::DateCalculator`
 
 ## 4.7.0
 

--- a/lib/generated_definitions/fedex.rb
+++ b/lib/generated_definitions/fedex.rb
@@ -26,7 +26,7 @@ module Holidays
     def self.custom_methods
       {
         "day_after_thanksgiving(year)" => Proc.new { |year|
-Holidays::DateCalculatorFactory.day_of_month_calculator.call(year, 11, 4, 4) + 1
+Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 11, 4, 4) + 1
 },
 
 

--- a/lib/holidays/date_calculator/day_of_month.rb
+++ b/lib/holidays/date_calculator/day_of_month.rb
@@ -15,15 +15,15 @@ module Holidays
     #
     # ===== Examples
     # First Monday of January, 2008:
-    #   Holidays::DateCalculatorFactory.day_of_month_calculator.call(2008, 1, :first, :monday)
+    #   Holidays::Factory::DateCalculator.day_of_month_calculator.call(2008, 1, :first, :monday)
     #   => 7
     #
     # Third Thursday of December, 2008:
-    #   Holidays::DateCalculatorFactory.day_of_month_calculator.call(2008, 12, :third, :thursday)
+    #   Holidays::Factory::DateCalculator.day_of_month_calculator.call(2008, 12, :third, :thursday)
     #   => 18
     #
     # Last Monday of January, 2008:
-    #   Holidays::DateCalculatorFactory.day_of_month_calculator.call(2008, 1, :last, 1)
+    #   Holidays::Factory::DateCalculator.day_of_month_calculator.call(2008, 1, :last, 1)
     #   => 28
     #--
     # see http://www.irt.org/articles/js050/index.htm


### PR DESCRIPTION
I hit a hiccup when I was upgrading from 4.x to 5.x and because lots of definitions reference `DateCalculatorFactory`, I figured it made sense to update any errant references in the repo and also mention it in the changelog to make it easier to future upgraders. (You'll probably be getting a lot as folks run `bundle update` to get rails 5.1.)