### PR TITLE
changed carnival to easter related holidays for Argentine

### DIFF
--- a/lib/generated_definitions/ar.rb
+++ b/lib/generated_definitions/ar.rb
@@ -12,10 +12,12 @@ module Holidays
 
     def self.holidays_by_month
       {
-              0 => [{:function => "easter(year)", :function_arguments => [:year], :function_modifier => -2, :name => "Viernes Santo", :regions => [:ar]}],
+              0 => [{:function => "easter(year)", :function_arguments => [:year], :function_modifier => -2, :name => "Viernes Santo", :regions => [:ar]},
+                    {:function => "easter(year)", :function_arguments => [:year], :function_modifier => -48, :name => "Carnaval Lunes", :regions => [:ar]},
+                    {:function => "easter(year)", :function_arguments => [:year], :function_modifier => -47, :name => "Carnaval Martes", :regions => [:ar]}
+                   ],
       1 => [{:mday => 1, :name => "Año Nuevo", :regions => [:ar]}],
-      2 => [{:mday => 8, :name => "Carnaval", :regions => [:ar]},
-            {:mday => 9, :name => "Carnaval", :regions => [:ar]}],
+      2 => [],
       3 => [{:mday => 24, :name => "Día Nacional de la Memoria por la Verdad y la Justicia", :regions => [:ar]}],
       4 => [{:mday => 2, :name => "Día del Veterano y de los Caídos en la Guerra de Malvinas", :regions => [:ar]}],
       5 => [{:mday => 1, :name => "Día del Trabajador", :regions => [:ar]},

--- a/test/defs/test_defs_ar.rb
+++ b/test/defs/test_defs_ar.rb
@@ -9,9 +9,17 @@ class ArDefinitionTests < Test::Unit::TestCase  # :nodoc:
   def test_ar
     assert_equal "Año Nuevo", (Holidays.on(Date.civil(2016, 1, 1), [:ar], [:informal])[0] || {})[:name]
 
-    assert_equal "Carnaval", (Holidays.on(Date.civil(2016, 2, 8), [:ar], [:informal])[0] || {})[:name]
+    assert_equal "Carnaval Lunes", (Holidays.on(Date.civil(2016, 2, 8), [:ar], [:informal])[0] || {})[:name]
 
-    assert_equal "Carnaval", (Holidays.on(Date.civil(2016, 2, 9), [:ar], [:informal])[0] || {})[:name]
+    assert_equal "Carnaval Martes", (Holidays.on(Date.civil(2016, 2, 9), [:ar], [:informal])[0] || {})[:name]
+
+    assert_equal "Carnaval Lunes", (Holidays.on(Date.civil(2017, 2, 27), [:ar], [:informal])[0] || {})[:name]
+
+    assert_equal "Carnaval Martes", (Holidays.on(Date.civil(2017, 2, 28), [:ar], [:informal])[0] || {})[:name]
+
+    assert_equal "Carnaval Lunes", (Holidays.on(Date.civil(2018, 2, 12), [:ar], [:informal])[0] || {})[:name]
+
+    assert_equal "Carnaval Martes", (Holidays.on(Date.civil(2018, 2, 13), [:ar], [:informal])[0] || {})[:name]
 
     assert_equal "Día Nacional de la Memoria por la Verdad y la Justicia", (Holidays.on(Date.civil(2016, 3, 24), [:ar], [:informal])[0] || {})[:name]
 


### PR DESCRIPTION
I saw that the carnival holidays were fixated each year, both dates should be related to easter. Added it to the code and added a couple of years to test carnival. The problem that I had is both holidays could not have the same name, so I changed the name to Carnaval Lunes, Carnaval Martes, but really both days are the carnival.