### PR TITLE
Add explicit cache repo input validation

### DIFF
--- a/lib/holidays/definition/repository/cache.rb
+++ b/lib/holidays/definition/repository/cache.rb
@@ -8,6 +8,7 @@ module Holidays
 
         def cache_between(start_date, end_date, cache_data, options)
           raise ArgumentError unless cache_data
+          raise ArgumentError unless start_date && end_date
 
           @cache_range[options] = start_date..end_date
           @cache[options] = cache_data.group_by { |holiday| holiday[:date] }
@@ -15,7 +16,7 @@ module Holidays
 
         def find(start_date, end_date, options)
           return nil unless in_cache_range?(start_date, end_date, options)
-          
+
           if start_date == end_date
             @cache[options].fetch(start_date, [])
           else


### PR DESCRIPTION
This change adds an explicit guard for missing `start_date` and `end_date` input for the `cache_between` method of the cache repository. The reason for this is the new endless range in ruby 2.6.0.

The method previously implicitly performed input validation via syntax validation: a range needs both ends, e.g. `start_date..end_date`. But with the addition of [endless ranges](https://bugs.ruby-lang.org/issues/12912) this is no longer a valid plan.

We should have been doing explicit guards anyway.