### PR TITLE
Fix v7.1.0 CHANGELOG entry to remove incorrect reference to ruby 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 7.1.0
 
 * Update to [v4.1.0 definitions](https://github.com/holidays/definitions/releases/tag/v4.1.0). Please see the changelog for the definition details.
-* Add ruby 2.6 to automated tests
 
 ## 7.0.0
 


### PR DESCRIPTION
I mistakenly left a reference to ruby 2.6 in the v7.1.0 CHANGELOG entry. Sorry for any confusion that this caused.

We will be adding official support for ruby 2.6 and jruby 9.2.5.0 in the [v8.0.0 release](https://github.com/holidays/holidays/pull/339). We will also be dropping support for ruby 2.2, ruby 2.3, and jruby 9.0.5.0 since they are no longer supported (or in the case of 2.3 will soon be no longer supported).