### PR TITLE
Return ArgumentError from 'between' method if end_date is before start_date

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -40,6 +40,8 @@ module Holidays
 
       start_date, end_date = get_date(start_date), get_date(end_date)
 
+      return [] if end_date < start_date
+
       if cached_holidays = Factory::Definition.cache_repository.find(start_date, end_date, options)
         return cached_holidays
       end

--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -40,7 +40,7 @@ module Holidays
 
       start_date, end_date = get_date(start_date), get_date(end_date)
 
-      return [] if end_date < start_date
+      raise ArgumentError if end_date < start_date
 
       if cached_holidays = Factory::Definition.cache_repository.find(start_date, end_date, options)
         return cached_holidays

--- a/test/integration/test_holidays_between.rb
+++ b/test/integration/test_holidays_between.rb
@@ -29,6 +29,9 @@ class HolidaysBetweenTests < Test::Unit::TestCase
 
     holidays = @subject.call(Date.civil(2008,7,2), Date.civil(2008,7,31), :ca)
     assert_equal 0, holidays.length
+
+    holidays = @subject.call(Date.civil(2008,7,2), Date.civil(2000,7,2), :ca)
+    assert_equal 0, holidays.length
   end
 
   def test_between_raises_error_if_missing_start_or_end_date

--- a/test/integration/test_holidays_between.rb
+++ b/test/integration/test_holidays_between.rb
@@ -29,9 +29,6 @@ class HolidaysBetweenTests < Test::Unit::TestCase
 
     holidays = @subject.call(Date.civil(2008,7,2), Date.civil(2008,7,31), :ca)
     assert_equal 0, holidays.length
-
-    holidays = @subject.call(Date.civil(2008,7,2), Date.civil(2000,7,2), :ca)
-    assert_equal 0, holidays.length
   end
 
   def test_between_raises_error_if_missing_start_or_end_date
@@ -41,6 +38,16 @@ class HolidaysBetweenTests < Test::Unit::TestCase
 
     assert_raise ArgumentError do
       @subject.call(Date.civil(2015, 1, 1), nil, :us)
+    end
+  end
+
+  def test_between_raises_error_if_end_date_is_before_start_date
+    assert_raise ArgumentError do
+      @subject.call(Date.civil(2019, 2, 1), Date.civil(2019, 1, 1), :us)
+    end
+
+    assert_raise ArgumentError do
+      @subject.call(Date.civil(2008,7,2), Date.civil(2000,7,2), :ca)
     end
   end
 


### PR DESCRIPTION
This is based off of https://github.com/holidays/holidays/pull/317 but returns an `ArgumentError` instead of an empty array if the `end_date` is before the `start_date`.