### PR TITLE
Remove test about feb 29 on non leap year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - 2.7.1
   - ruby-head
   - jruby-9.2.6.0
   - jruby-head

--- a/test/integration/test_holidays.rb
+++ b/test/integration/test_holidays.rb
@@ -142,28 +142,6 @@ class HolidaysTests < Test::Unit::TestCase
     assert_empty holidays
   end
 
-  def test_year_holidays_feb_29_on_non_leap_year
-    assert_raises ArgumentError do
-      Holidays.year_holidays([:ca_on], Date.civil(2015, 2, 29))
-    end
-
-    assert_raises ArgumentError do
-      Holidays.year_holidays([:ca_on], Date.civil(2019, 2, 29))
-    end
-
-    assert_raises ArgumentError do
-      Holidays.year_holidays([:ca_on], Date.civil(2021, 2, 29))
-    end
-
-    assert_raises ArgumentError do
-      Holidays.year_holidays([:us], Date.civil(2023, 2, 29))
-    end
-
-    assert_raises ArgumentError do
-      Holidays.year_holidays([:ca_on], Date.civil(2025, 2, 29))
-    end
-  end
-
   def test_year_holidays_random_years
     # Should be 1 less holiday, as Family day didn't exist in Ontario in 1990
     holidays = Holidays.year_holidays([:ca_on], Date.civil(1990, 1, 1))


### PR DESCRIPTION
The following code raises an error as of calling Date, so it does not test Holidays gem.
Code coverage is not changed even if removes this test.

`Holidays.year_holidays(:ca_on], Date.civil(2015, 2, 29))`

And the error which `Date.civil(2015, 2, 29)` raises is changed since Ruby 2.7.

```
> Date.civil(2015, 2, 29)

# 2.6 or earlier
 => ArgumentError: invalid date
# 2.7
 => Date::Error: invalid date
```

So all tests pass on Ruby 2.7 by this change.