### PR TITLE
Update ruby_version requirement to allow ruby 3.0

### DIFF
--- a/holidays.gemspec
+++ b/holidays.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^test/)
   gem.require_paths = ['lib']
   gem.licenses      = ['MIT']
-  gem.required_ruby_version = '~> 2.4'
+  gem.required_ruby_version = '>= 2.4'
   gem.add_development_dependency 'bundler', '~> 2'
   gem.add_development_dependency 'rake', '~> 12'
   gem.add_development_dependency 'simplecov', '~> 0.16'


### PR DESCRIPTION
Ruby master branch recently bumped the version number to 3.0: https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11

This is breaking our ruby-head CI.