### PR TITLE
Add testing for ruby 3.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ rvm:
   - 2.5.5
   - 2.6.3
   - 2.7.1
+  - 3.0.2
   - ruby-head
   - jruby-9.2.6.0
   - jruby-head

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This gem is tested with the following ruby versions:
   * 2.4.5
   * 2.5.3
   * 2.6.1
+  * 2.7.1
+  * 3.0.2
   * JRuby 9.2.5.0
 
 ## Semver


### PR DESCRIPTION
- [x] automated tests pass locally
- [x] added 3.0.2 to travis.yml
- [x] updated readme to indicate 3.0.2 (and 2.7.1) are tested