### PR TITLE
tests for Juneteenth in federalreserve and federalreservebanks

### DIFF
--- a/test/defs/test_defs_federalreserve.rb
+++ b/test/defs/test_defs_federalreserve.rb
@@ -109,5 +109,11 @@ class FederalreserveDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "Christmas Day", (Holidays.on(Date.civil(2016, 12, 26), [:federalreserve], [:observed])[0] || {})[:name]
 
+    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2021, 6, 18), [:federalreserve], [:observed])[0] || {})[:name]
+
+    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2022, 6, 20), [:federalreserve], [:observed])[0] || {})[:name]
+
+    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2023, 6, 19), [:federalreserve], [:observed])[0] || {})[:name]
+
   end
 end

--- a/test/defs/test_defs_federalreservebanks.rb
+++ b/test/defs/test_defs_federalreservebanks.rb
@@ -15,9 +15,11 @@ class FederalreservebanksDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "Memorial Day", (Holidays.on(Date.civil(2012, 5, 28), [:federalreservebanks], [:observed])[0] || {})[:name]
 
-    assert_nil (Holidays.on(Date.civil(2021, 6, 19), [:federalreservebanks], [:observed])[0] || {})[:name]
+    assert_nil (Holidays.on(Date.civil(2021, 6, 18), [:federalreservebanks], [:observed])[0] || {})[:name]
 
-    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2021, 6, 18), [:federalreservebanks], [:observed])[0] || {})[:name]
+    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2022, 6, 20), [:federalreservebanks], [:observed])[0] || {})[:name]
+
+    assert_equal "Juneteenth National Independence Day", (Holidays.on(Date.civil(2023, 6, 19), [:federalreservebanks], [:observed])[0] || {})[:name]
 
     assert_equal "Independence Day", (Holidays.on(Date.civil(2012, 7, 4), [:federalreservebanks], [:observed])[0] || {})[:name]
 


### PR DESCRIPTION
These are the tests for Juneteenth holiday. Can we merged after the updated definitions are merged from this PR: https://github.com/holidays/definitions/pull/214