### PR TITLE
Test against Ruby 3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ rvm:
   - 2.5.5
   - 2.6.3
   - 2.7.1
+  - 3.2.0
   - ruby-head
   - jruby-9.2.6.0
   - jruby-head

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This gem is tested with the following ruby versions:
   * 2.4.5
   * 2.5.3
   * 2.6.1
+  * 3.2.0
   * JRuby 9.2.5.0
 
 ## Semver


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/