### PR TITLE
Get defs branch using HTTPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ update-defs: definitions/
 definitions: point-to-defs-master
 
 point-to-defs-branch:
-	git submodule add -b $(BRANCH) git@github.com:$(USER)/definitions.git definitions/
+	git submodule add -b $(BRANCH) https://github.com/$(USER)/definitions.git ./definitions/
 
 point-to-defs-master:
 	git submodule add https://github.com/holidays/definitions definitions/


### PR DESCRIPTION
Use HTTPS to get the definitions branch, which I believe is the preferred way to access GitHub these days, and also makes the `point-to-defs-branch` action consistent with the `point-to-defs-master` action.

Feel free to ignore this PR if there's a reason to use SSH to pull the WIP definitions branch.