### PR TITLE
Fix link to the build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ruby Holidays Gem [![Build Status](https://travis-ci.org/holidays/holidays.svg?branch=master)](https://travis-ci.org/holidays/holidays)
+# Ruby Holidays Gem [![Build Status](https://github.com/holidays/holidays/actions/workflows/ruby.yml/badge.svg)](https://github.com/holidays/holidays/actions/workflows/ruby.yml)
 
 Functionality to deal with holidays in Ruby.
 


### PR DESCRIPTION
The link of the `Build Status` pointed to the Travis CI, but this repository doesn't use it. This PR fixes to the link to the GitHub Actions.