### PR TITLE
CI against Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'ruby-head']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head']
     env:
       BUNDLER_NO_OLD_RUBYGEMS_WARNING: true
     steps:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This gem is tested with the following ruby versions:
   * 3.0.6
   * 3.1.4
   * 3.2.2
+  * 3.3.0
   * JRuby 9.2.21.0
   * JRuby 9.4.2.0
 


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI matrix to ensure `holidays` work with Ruby 3.3