### PR TITLE
Bring back CI against Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'ruby-head']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head']
     env:
       BUNDLER_NO_OLD_RUBYGEMS_WARNING: true
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@943103cae7d3f1bb1e4951d5fcc7928b40e4b742 #v1.177.1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
CI against Ruby 3.3 was removed by 93c9e66f7add7f9f407c0b21732265bae923c618 because CI failed.
https://github.com/holidays/holidays/actions/runs/9203750717/job/25315881768

This is because of using the old `ruby/setup-ruby` action. 
This bump the action and bring back CI against Ruby 3.3