### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'ruby-head']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'ruby-head']
     env:
       BUNDLER_NO_OLD_RUBYGEMS_WARNING: true
     steps:

--- a/test/holidays/definition/generator/test_regions.rb
+++ b/test/holidays/definition/generator/test_regions.rb
@@ -14,7 +14,7 @@ class GeneratorRegionsTests < Test::Unit::TestCase
 module Holidays
   REGIONS = [:test, :test2]
 
-  PARENT_REGION_LOOKUP = {:test=>:region1, :test2=>:region1}
+  PARENT_REGION_LOOKUP = #{{:test=>:region1, :test2=>:region1}}
 end
 EOE
 
@@ -28,7 +28,7 @@ EOE
 module Holidays
   REGIONS = [:test, :test2]
 
-  PARENT_REGION_LOOKUP = {:test=>:region1, :test2=>:region2}
+  PARENT_REGION_LOOKUP = #{{:test=>:region1, :test2=>:region2}}
 end
 EOE
 
@@ -42,7 +42,7 @@ EOE
 module Holidays
   REGIONS = [:test, :test2, :test3]
 
-  PARENT_REGION_LOOKUP = {:test=>:region1, :test2=>:region2, :test3=>:region3}
+  PARENT_REGION_LOOKUP = #{{:test=>:region1, :test2=>:region2, :test3=>:region3}}
 end
 EOE
 
@@ -64,7 +64,7 @@ EOE
 module Holidays
   REGIONS = [:test, :test2, :test3, :test4, :test5, :test6]
 
-  PARENT_REGION_LOOKUP = {:test=>:region1, :test2=>:region2, :test3=>:region3, :test4=>:region4, :test5=>:region5, :test6=>:region6}
+  PARENT_REGION_LOOKUP = #{{:test=>:region1, :test2=>:region2, :test3=>:region3, :test4=>:region4, :test5=>:region5, :test6=>:region6}}
 end
 EOE
 


### PR DESCRIPTION
This PR adds Ruby 3.4 to the CI matrix to confirm `holidays` gem works with Ruby 3.4.

In Ruby 3.4,  the result of `Hash.inspect` has changed. So I updated some specs to wrap hash with `#{}` to work both 3.4 and older.
Ref: https://bugs.ruby-lang.org/issues/20433