### PR TITLE
Add irb and rdoc to dev deps to silence warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development do
+  gem 'irb'
+  gem 'rdoc'
+end


### PR DESCRIPTION
Silence the warnings about the update to ruby 4:

```
$  make console
bundle exec rake console
irb -r rubygems -I lib -r holidays.rb
/home/phil/.rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/irb-1.14.3/exe/irb:7: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.0.0.
You can add irb to your Gemfile or gemspec to silence this warning.
/home/phil/.rbenv/versions/3.4.9/lib/ruby/3.4.0/irb/input-method.rb:278: warning: rdoc was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 4.0.0.
You can add rdoc to your Gemfile or gemspec to silence this warning.
irb(main):001>
```

This is replaced by the nice new hotness now: 

```
make console
bundle exec rake console
irb -r rubygems -I lib -r holidays.rb

⢀⡴⠊⢉⡟⢿  IRB v1.18.0 - Ruby 3.4.9
⣎⣀⣴⡋⡟⣻  "edit method" to open the method's source in editor
⣟⣼⣱⣽⣟⣾  ~/dev/ppeble/holidays

irb(main):001>
```