### PR TITLE
Gate release on Ruby workflow passing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,15 @@
 name: Release
 on:
-  push:
+  workflow_run:
+    workflows: ["Ruby"]
+    types: [completed]
     branches: ["master"]
 permissions:
   contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     env:
       BUNDLER_NO_OLD_RUBYGEMS_WARNING: true
     steps:


### PR DESCRIPTION
I want the publish to only happen after the full 'master' pipeline finishes. This ensures this scenario.