### PR TITLE
Add AI usage policy, move CONTRIBUTING to root, add commit requirements

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,65 @@
+# AI Usage Policy
+
+The `holidays` project has strict rules for AI usage:
+
+- **All AI usage in any form must be disclosed.** You must state
+  the tool you used (e.g. Claude Code, Cursor, Amp) along with
+  the extent that the work was AI-assisted.
+
+- **The human-in-the-loop must fully understand all code.** If you
+  can't explain what your changes do and how they interact with the
+  greater system without the aid of AI tools, do not contribute
+  to this project.
+
+- **Issues and discussions can use AI assistance but must have a full
+  human-in-the-loop.** This means that any content generated with AI
+  must have been reviewed _and edited_ by a human before submission.
+  AI is very good at being overly verbose and including noise that
+  distracts from the main point. Humans must do their research and
+  trim this down.
+
+- **No AI-generated media is allowed (art, images, videos, audio, etc.).**
+  Text and code are the only acceptable AI-generated content, per the
+  other rules in this policy.
+
+- **Low-effort, unreviewed AI output ("slop") will be closed without
+  ceremony** and may result in your contributions being blocked in the
+  future.
+
+These rules apply only to outside contributions to this project. Maintainers
+are exempt from these rules and may use AI tools at their discretion;
+they've proven themselves trustworthy to apply good judgment.
+
+## There are Humans Here
+
+Please remember that this project is maintained by humans.
+
+Every discussion, issue, and pull request is read and reviewed by
+humans (and sometimes machines, too). It is a boundary point at which
+people interact with each other and the work done. It is rude and
+disrespectful to approach this boundary with low-effort, unqualified
+work, since it puts the burden of validation on the maintainer.
+
+In a perfect world, AI would produce high-quality, accurate work
+every time. But today, that reality depends on the driver of the AI.
+And today, most drivers of AI are just not good enough. So, until either
+the people get better, the AI gets better, or both, we have to have
+strict rules to protect maintainers.
+
+## AI is Welcome Here
+
+This project is maintained with plenty of AI assistance, and the maintainers embrace
+AI tools as a productive tool in their workflow. As a project, we welcome
+AI as a tool!
+
+**Our reason for the strict AI policy is not due to an anti-AI stance**, but
+instead due to the number of highly unqualified people using AI. It's the
+people, not the tools, that are the problem.
+
+I include this section to be transparent about the project's usage of
+AI for people who may disagree with it, and to address the misconception
+that this policy is anti-AI in nature.
+
+## Influences
+
+This policy is heavily inspired by the [Ghostty AI Usage Policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,33 @@ There are multiple ways to help! We rely on users around the world to help keep 
 
 ## Code of Conduct
 
-Please read our [Code of Conduct](../CODE_OF_CONDUCT.md) before contributing. Everyone interacting with this project (or associated projects) is expected to abide by its terms.
+Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing. Everyone interacting with this project (or associated projects) is expected to abide by its terms.
+
+## AI Usage
+
+Please read our [AI Usage Policy](AI_POLICY.md) before contributing.
+
+## Commit requirements
+
+All commits must be GPG-signed and include a `Signed-off-by` trailer. Use both
+the `-S` and `-s` flags together:
+
+```sh
+git commit -S -s -m "Your commit message"
+```
+
+**GPG signing** (`-S`) verifies that the commit genuinely came from you. If you
+haven't set up GPG signing with Git yet, GitHub has a guide:
+https://docs.github.com/en/authentication/managing-commit-signature-verification
+
+**Signed-off-by** (`-s`) is your acknowledgment of the
+[Developer Certificate of Origin](https://developercertificate.org/), certifying
+that you have the right to submit the contribution under this project's license.
+It appends the following to your commit message automatically:
+
+```
+Signed-off-by: Your Name <your@email.com>
+```
 
 ## General note
 


### PR DESCRIPTION
This is an initial attempt at an AI policy. I have basically copied the [Ghostty](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md) version. I tend to agree with it.

I am going to leave this open for comment for quite a bit since it's just about policy.

@ttwo32 @gregoryfm ^^