### PR TITLE
Clarify that nil is a valid return from custom definition functions

### DIFF
--- a/lib/holidays/definition/context/function_processor.rb
+++ b/lib/holidays/definition/context/function_processor.rb
@@ -74,11 +74,10 @@ module Holidays
               raise Holidays::InvalidFunctionResponse.new("invalid day response from custom method call resulting in invalid date. Result: '#{result}'")
             end
           elsif result.nil?
-            # Do nothing. This is because some functions can return 'nil' today.
-            # I want to change this and so rather than come up with a clean
-            # implementation I'll do this so we don't throw an error in this specific
-            # situation. This should be removed once we have changed the existing
-            # custom definition functions. See https://github.com/holidays/holidays/issues/204
+            # nil is a valid return value meaning the calculation determined that no
+            # holiday exists on this date. For example, jp_substitute_holiday returns
+            # nil when the original holiday does not fall on a Sunday (no substitute
+            # needed), and us_inauguration_day returns nil when year % 4 != 1.
           else
             raise Holidays::InvalidFunctionResponse.new("invalid response from custom method call, must be a 'date' or 'integer' representing the day. Result: '#{result}'")
           end


### PR DESCRIPTION
Closes #204 (partially — the premise that all nil returns are wrong does not hold; see the definitions repo PR for the definition-side changes).