### PR TITLE
Clarify that the gem returns statutory holidays by default and link to definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Functionality to deal with holidays in Ruby.
 
 Extends Ruby's built-in Date and Time classes and supports custom holiday definition lists.
 
+All holiday definitions are maintained in the [holidays/definitions](https://github.com/holidays/definitions) repository. By default this gem returns statutory (formally government-defined) holidays. Culturally recognized but non-statutory holidays (such as Valentine's Day) are available via the `:informal` option. See the [definitions syntax guide](https://github.com/holidays/definitions/blob/master/doc/SYNTAX.md#formalinformal) for details on how holidays are classified.
+
 ## Installation
 
 ```


### PR DESCRIPTION
## Summary

- Adds a paragraph near the top of the README explaining that all definitions come from the [holidays/definitions](https://github.com/holidays/definitions) repository
- Explains that the gem returns statutory (formally government-defined) holidays by default, and that `:informal` is the opt-in for culturally recognized but non-statutory holidays
- Links to the definitions syntax guide for further detail

Companion PR in definitions: https://github.com/holidays/definitions/pull/332

## Test plan

- [x] Review README change for accuracy and clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)