### PR TITLE
Bump actions/checkout to v5.0.1 and ruby/setup-ruby to v1.306.0

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
       - name: Extract version from version.rb
         id: version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     env:
       BUNDLER_NO_OLD_RUBYGEMS_WARNING: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
       - name: Set up Ruby
-        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 #v1.299.0
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f #v1.306.0
         with:
           ruby-version: 'ruby'
           bundler-cache: true

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,9 +15,9 @@ jobs:
     env:
       BUNDLER_NO_OLD_RUBYGEMS_WARNING: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
     - name: Set up Ruby
-      uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 #v1.299.0
+      uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f #v1.306.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler: latest


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from `v3` to `v5.0.1` (SHA-pinned) in all three workflows. `v3` runs on Node.js 20, which GitHub is deprecating: forced to Node 24 on 2026-06-02 and removed entirely on 2026-09-16
- Bumps `ruby/setup-ruby` from `v1.299.0` to `v1.306.0` (SHA-pinned) in `ruby.yml` and `release.yml`, just gets us to latest, no changes that affect us