### PR TITLE
Document wildcard regions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,35 @@ You can leave off 'regions' to get holidays for any region in our [definitions](
    ]
 ```
 
+#### Wildcard regions
+
+A region ending in an underscore (e.g. `:au_`, `:ca_`) is a *wildcard*. It matches the
+parent country region **and all of its sub-regions** in a single call:
+
+```ruby
+Holidays.on(Date.new(2017, 3, 13), :au_)
+=> [{:name=>"Eight Hours Day", :regions=>[:au_tas],...},
+    {:name=>"Labour Day", :regions=>[:au_vic],...},
+    {:name=>"March Public Holiday", :regions=>[:au_sa],...},
+    {:name=>"Canberra Day", :regions=>[:au_act],...}]
+```
+
+The same date queried with the plain `:au` region returns nothing, because none of
+those holidays are observed nation-wide:
+
+```ruby
+Holidays.on(Date.new(2017, 3, 13), :au)
+=> []
+```
+
+Use a wildcard when you want "this country and every sub-region it defines" without
+listing each sub-region explicitly.
+
+Note that a wildcard always collapses to the **top-level** country region. The portion
+between the country prefix and the trailing underscore is ignored, so `:au_vic_` behaves
+identically to `:au_` (it loads every Australian sub-region, not just Victoria's). There
+is currently no way to wildcard-match only the children of a sub-region.
+
 #### Checking a date range
 
 Get all holidays during the month of July 2008 in Canada and the US:

--- a/test/holidays/finder/context/test_parse_options.rb
+++ b/test/holidays/finder/context/test_parse_options.rb
@@ -61,6 +61,17 @@ class ParseOptionsTests < Test::Unit::TestCase
     assert_equal(false, regions.include?(:ch_))
   end
 
+  # A multi-segment wildcard collapses to the top-level country prefix: only
+  # the portion before the first underscore is used, so :ch_zh_ behaves
+  # identically to :ch_ and loads every Swiss sub-region, not just Zurich's.
+  def test_multi_segment_wildcard_collapses_to_top_level_region
+    @definition_loader.expects(:call).with(:ch).returns([:ch, :ch_zh])
+
+    regions = @subject.call([:ch_zh_]).first
+
+    assert_equal([:ch, :ch_zh], regions)
+  end
+
   def test_does_nothing_if_region_is_already_loaded_and_is_parent
     @regions_repo.expects(:parent_region_lookup).with(:test).returns(nil)
     regions = @subject.call([:test]).first


### PR DESCRIPTION
Adds a "Wildcard regions" subsection to the README explaining how trailing-underscore regions (e.g. `:au_`, `:ca_`) behave.

The behavior was previously undocumented. The new section covers:

- What a wildcard region is and the syntax (trailing underscore).
- That it matches the parent country plus all of its sub-regions in one call, with a verified `:au_` example.
- The contrast with the plain country region (`:au` returns nothing for state-specific holidays).
- The caveat that a wildcard always collapses to the top-level country prefix, so `:au_vic_` behaves identically to `:au_`.

All examples were verified by running the gem locally.

Closes #267