### PR TITLE
Document that tests in custom definition files are not run at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,12 @@ Holidays.load_custom(
 )
 ```
 
+Note that any `tests:` stanzas in a custom definition file are ignored by
+`load_custom`. Tests are only executed at build time for definitions contributed
+to the [definitions repository](https://github.com/holidays/definitions), where
+`rake generate` turns them into the test suite. There is no runtime mechanism to
+run the tests embedded in a custom file loaded on the fly.
+
 ## Extending Ruby's Date and Time classes
 
 ### Date


### PR DESCRIPTION
Fixes #304. Clarifies in the README that `tests:` stanzas in custom definition files loaded via `load_custom` are ignored at runtime; tests only run at build time for definitions contributed upstream.