### PR TITLE
Raise an error when a definition references an unknown function

### DIFF
--- a/lib/holidays/definition/context/generator.rb
+++ b/lib/holidays/definition/context/generator.rb
@@ -201,6 +201,8 @@ module Holidays
             method.parameters.collect { |arg| arg[1] }
           elsif method = parsed_custom_methods[function_id]
             method.arguments.collect { |arg| arg.to_sym }
+          else
+            raise ArgumentError, "Unknown function '#{function_id}'. It must either be a built-in method or be defined in the 'methods' section of a definition file."
           end
         end
       end

--- a/test/data/test_invalid_function_defs.yaml
+++ b/test/data/test_invalid_function_defs.yaml
@@ -1,0 +1,5 @@
+months:
+  6:
+  - name: Invalid Function Holiday
+    regions: [custom_invalid_function_file]
+    function: to_weekday_if_sunday(date)

--- a/test/holidays/definition/context/test_generator.rb
+++ b/test/holidays/definition/context/test_generator.rb
@@ -41,6 +41,18 @@ class GeneratorTests < Test::Unit::TestCase
     end
   end
 
+  def test_parse_definition_files_raises_error_for_unknown_function
+    files = ['test/data/test_invalid_function_defs.yaml']
+    @custom_method_parser.expects(:call).with(nil).returns({})
+    @custom_methods_repository.expects(:find).with('to_weekday_if_sunday(date)').returns(nil)
+
+    error = assert_raises ArgumentError do
+      @generator.parse_definition_files(files)
+    end
+
+    assert_match(/Unknown function 'to_weekday_if_sunday\(date\)'/, error.message)
+  end
+
   def test_parse_definition_files_correctly_parse_regions
     files = ['test/data/test_single_custom_holiday_defs.yaml']
     @custom_method_parser.expects(:call).with(nil).returns({})


### PR DESCRIPTION
Fixes #333. Definition generation previously ignored references to functions that were neither built-in methods nor defined in a definition file's `methods` section, so typos like `to_weekday_if_sunday` passed silently. `get_function_arguments` now raises an `ArgumentError` when a referenced function cannot be resolved, covering both `function:` and `observed:` references (and `load_custom` at runtime). Verified that `rake generate` still regenerates every existing definition with no changes.