### PR TITLE
Do not merge same-name holidays that differ by function modifier

### DIFF
--- a/lib/holidays/definition/context/generator.rb
+++ b/lib/holidays/definition/context/generator.rb
@@ -110,7 +110,7 @@ module Holidays
 
                 exists = false
                 rules_by_month[month].each do |ex|
-                  if ex[:name] == rule[:name] and ex[:wday] == rule[:wday] and ex[:mday] == rule[:mday] and ex[:week] == rule[:week] and ex[:type] == rule[:type] and ex[:function] == rule[:function] and ex[:observed] == rule[:observed] and ex[:year_ranges] == rule[:year_ranges]
+                  if ex[:name] == rule[:name] and ex[:wday] == rule[:wday] and ex[:mday] == rule[:mday] and ex[:week] == rule[:week] and ex[:type] == rule[:type] and ex[:function] == rule[:function] and ex[:function_modifier] == rule[:function_modifier] and ex[:observed] == rule[:observed] and ex[:year_ranges] == rule[:year_ranges]
                     ex[:regions] << rule[:regions].flatten
                     exists = true
                   end

--- a/test/data/test_same_name_different_modifier_defs.yaml
+++ b/test/data/test_same_name_different_modifier_defs.yaml
@@ -1,0 +1,9 @@
+months:
+  0:
+  - name: Same Name Holiday
+    regions: [custom_same_name_file]
+    function: easter(year)
+  - name: Same Name Holiday
+    regions: [custom_same_name_file]
+    function: easter(year)
+    function_modifier: 1

--- a/test/holidays/definition/context/test_generator.rb
+++ b/test/holidays/definition/context/test_generator.rb
@@ -53,6 +53,18 @@ class GeneratorTests < Test::Unit::TestCase
     assert_match(/Unknown function 'to_weekday_if_sunday\(date\)'/, error.message)
   end
 
+  def test_parse_definition_files_keeps_same_name_holidays_with_different_modifiers
+    files = ['test/data/test_same_name_different_modifier_defs.yaml']
+    @custom_method_parser.expects(:call).with(nil).returns({})
+    @custom_methods_repository.stubs(:find).with('easter(year)').returns(->(year) {})
+    @test_parser.expects(:call).with(nil).returns([])
+
+    rules_by_month = @generator.parse_definition_files(files)[1]
+
+    assert_equal 2, rules_by_month[0].length
+    assert_equal [nil, 1], rules_by_month[0].map { |r| r[:function_modifier] }
+  end
+
   def test_parse_definition_files_correctly_parse_regions
     files = ['test/data/test_single_custom_holiday_defs.yaml']
     @custom_method_parser.expects(:call).with(nil).returns({})


### PR DESCRIPTION
Fixes #352 

The definition generator's dedup check merged two holidays as the same entry when their name, region, and function matched, but it did not compare `function_modifier`. 