### PR TITLE
Release 10.0.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4', '4.0', 'ruby-head', 'jruby-10.0.4.0']
+        ruby-version: ['3.3', '3.4', '4.0', 'ruby-head', 'jruby-10.0.5.0']
     env:
       BUNDLER_NO_OLD_RUBYGEMS_WARNING: true
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Ruby Holidays Gem CHANGELOG
 
+## 10.0.0
+
+* Drop support for Ruby 3.2. Supported versions are now 3.3, 3.4, 4.0, and ruby-head.
+* Update to [v7.0.0 definitions](https://github.com/holidays/definitions/releases/tag/v7.0.0). Please see the changelog for the definition details.
+* Bump tested JRuby from 10.0.4.0 to 10.0.5.0
+* Raise an `ArgumentError` during definition parsing when a `function` or `observed` rule references an unknown method ([#333](https://github.com/holidays/holidays/issues/333))
+* Fix bug ([#352](https://github.com/holidays/holidays/issues/352)) where holidays with the same name and region that differed only by their function modifier were merged into a single entry, dropping one of the dates
+* Document that `tests` stanzas in custom definition files loaded via `load_custom` are not run at runtime ([#304](https://github.com/holidays/holidays/issues/304))
+
 ## 9.2.0
 
 * Update to [v6.1.1 definitions](https://github.com/holidays/definitions/releases/tag/v6.1.1). Please see the changelog for the definition details.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ gem install holidays
 
 This gem is tested with the following ruby versions:
 
-  * 3.2
   * 3.3
   * 3.4
   * 4.0
-  * JRuby 10.0.4.0
+  * JRuby 10.0.5.0
 
 ## Semver
 

--- a/holidays.gemspec
+++ b/holidays.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files lib`.split("\n") + ['CHANGELOG.md', 'LICENSE', 'README.md']
   gem.require_paths = ['lib']
   gem.licenses      = ['MIT']
-  gem.required_ruby_version = '>= 3.2'
+  gem.required_ruby_version = '>= 3.3'
   gem.add_development_dependency 'bundler', '>= 4'
   gem.add_development_dependency 'rake', '~> 13'
   gem.add_development_dependency 'simplecov', '~> 0.16'

--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -24,19 +24,20 @@ module Holidays
       3 => [{:wday => 1, :week => 1, :name => "Labour Day", :regions => [:au_wa]},
             {:wday => 1, :week => 2, :name => "Eight Hours Day", :regions => [:au_tas]},
             {:wday => 1, :week => 2, :name => "Labour Day", :regions => [:au_vic]},
-            {:function => "march_pub_hol_sa(year)", :function_arguments => [:year], :name => "March Public Holiday", :regions => [:au_sa]},
+            {:function => "march_pub_hol_sa(year)", :function_arguments => [:year], :year_ranges => { :from => 2006 },:name => "March Public Holiday", :regions => [:au_sa]},
             {:wday => 1, :week => 2, :name => "Canberra Day", :regions => [:au_act]}],
       4 => [{:mday => 25, :name => "ANZAC Day", :regions => [:au, :au_vic]},
             {:mday => 25, :observed => "to_monday_if_sunday(date)", :observed_arguments => [:date], :name => "ANZAC Day", :regions => [:au_qld, :au_nt, :au_act, :au_sa]},
             {:mday => 25, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "ANZAC Day", :regions => [:au_wa]}],
-      5 => [{:function => "qld_labour_day_may(year)", :function_arguments => [:year], :name => "Labour Day", :regions => [:au_qld]},
+      5 => [{:function => "qld_labour_day_may(year)", :function_arguments => [:year], :year_ranges => { :until => 2012 },:name => "Labour Day", :regions => [:au_qld]},
+            {:function => "qld_labour_day_may(year)", :function_arguments => [:year], :year_ranges => { :from => 2016 },:name => "Labour Day", :regions => [:au_qld]},
             {:wday => 1, :week => 1, :name => "May Day", :regions => [:au_nt]},
-            {:function => "may_pub_hol_sa(year)", :function_arguments => [:year], :name => "May Public Holiday", :regions => [:au_sa]},
+            {:function => "may_pub_hol_sa(year)", :function_arguments => [:year], :year_ranges => { :until => 2005 },:name => "May Public Holiday", :regions => [:au_sa]},
             {:mday => 27, :function => "to_nearest_monday_after(date)", :function_arguments => [:date], :year_ranges => { :from => 2018 },:name => "Reconciliation Day", :regions => [:au_act]}],
       6 => [{:wday => 1, :week => 1, :name => "Western Australia Day", :regions => [:au_wa]},
             {:wday => 1, :week => 2, :year_ranges => { :until => 2022 },:name => "Queen's Birthday", :regions => [:au_act, :au_nsw, :au_sa, :au_tas, :au_nt, :au_vic]},
             {:wday => 1, :week => 2, :year_ranges => { :from => 2023 },:name => "King's Birthday", :regions => [:au_act, :au_nsw, :au_sa, :au_tas, :au_nt, :au_vic]},
-            {:function => "qld_queens_birthday_june(year)", :function_arguments => [:year], :name => "Queen's Birthday", :regions => [:au_qld]},
+            {:function => "qld_queens_birthday_june(year)", :function_arguments => [:year], :year_ranges => { :until => 2015 },:name => "Queen's Birthday", :regions => [:au_qld]},
             {:mday => 6, :type => :informal, :name => "Queensland Day", :regions => [:au_qld]}],
       7 => [{:wday => 5, :week => 3, :name => "Cairns Show", :regions => [:au_qld_cairns]}],
       8 => [{:function => "qld_brisbane_ekka_holiday(year)", :function_arguments => [:year], :name => "Ekka", :regions => [:au_qld_brisbane]}],
@@ -46,11 +47,12 @@ module Holidays
             {:wday => 1, :week => -1, :year_ranges => { :until => 2017 },:name => "Family & Community Day", :regions => [:au_act]}],
       10 => [{:function => "afl_grand_final(year)", :function_arguments => [:year], :name => "Friday before the AFL Grand Final", :regions => [:au_vic]},
             {:wday => 1, :week => 1, :name => "Labour Day", :regions => [:au_act, :au_nsw, :au_sa]},
-            {:function => "qld_labour_day_october(year)", :function_arguments => [:year], :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Labour Day", :regions => [:au_qld]},
-            {:function => "qld_queens_bday_october(year)", :function_arguments => [:year], :year_ranges => { :until => 2022 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Queen's Birthday", :regions => [:au_qld]},
+            {:function => "qld_labour_day_october(year)", :function_arguments => [:year], :year_ranges => { :between => 2013..2015 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Labour Day", :regions => [:au_qld]},
+            {:mday => 1, :year_ranges => { :limited => [2012] },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Queen's Birthday", :regions => [:au_qld]},
+            {:function => "qld_queens_bday_october(year)", :function_arguments => [:year], :year_ranges => { :between => 2016..2022 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Queen's Birthday", :regions => [:au_qld]},
             {:function => "qld_kings_bday_october(year)", :function_arguments => [:year], :year_ranges => { :from => 2023 },:observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "King's Birthday", :regions => [:au_qld]},
             {:function => "hobart_show_day(year)", :function_arguments => [:year], :name => "Royal Hobart Show", :regions => [:au_tas_south]}],
-      11 => [{:function => "g20_day_2014_only(year)", :function_arguments => [:year], :name => "G20 Day", :regions => [:au_qld_brisbane]},
+      11 => [{:mday => 14, :year_ranges => { :limited => [2014] },:name => "G20 Day", :regions => [:au_qld_brisbane]},
             {:wday => 1, :week => 1, :name => "Recreation Day", :regions => [:au_tas_north]},
             {:wday => 2, :week => 1, :name => "Melbourne Cup Day", :regions => [:au_vic_melbourne]}],
       12 => [{:mday => 25, :observed => "to_tuesday_if_sunday_or_monday_if_saturday(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:au_qld, :au_nsw, :au_act, :au_tas, :au_wa, :au_vic, :au_nt]},
@@ -85,43 +87,23 @@ end
 },
 
 "qld_queens_bday_october(year)" => Proc.new { |year|
-if year >= 2016
-  Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
-elsif year == 2012
-  1
-else
-  nil
-end
+Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
 },
 
 "qld_kings_bday_october(year)" => Proc.new { |year|
-if year >= 2023
-  Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
-else
-  nil
-end
+Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
 },
 
 "qld_queens_birthday_june(year)" => Proc.new { |year|
-if year <= 2015
-  Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, 1)
-end
+Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 6, 2, 1)
 },
 
 "qld_labour_day_may(year)" => Proc.new { |year|
-if year < 2013 || year >= 2016
-  Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, 1, 1)
-end
+Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, 1, 1)
 },
 
 "qld_labour_day_october(year)" => Proc.new { |year|
-if year >= 2013 && year < 2016
-  Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
-end
-},
-
-"g20_day_2014_only(year)" => Proc.new { |year|
-year == 2014 ? 14 : nil
+Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 10, 1, 1)
 },
 
 "hobart_show_day(year)" => Proc.new { |year|
@@ -130,19 +112,11 @@ fourth_sat_in_oct - 2 # the thursday before
 },
 
 "march_pub_hol_sa(year)" => Proc.new { |year|
-if year < 2006
-  nil
-else
-  Date.civil(year, 3, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 3, :second, :monday))
-end
+Date.civil(year, 3, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 3, :second, :monday))
 },
 
 "may_pub_hol_sa(year)" => Proc.new { |year|
-if year >= 2006
-  nil
-else
-  Date.civil(year, 5, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, :third, :monday))
-end
+Date.civil(year, 5, Holidays::Factory::DateCalculator.day_of_month_calculator.call(year, 5, :third, :monday))
 },
 
 "qld_brisbane_ekka_holiday(year)" => Proc.new { |year|

--- a/lib/generated_definitions/europe.rb
+++ b/lib/generated_definitions/europe.rb
@@ -194,8 +194,8 @@ module Holidays
             {:mday => 1, :name => "Nieuwjaarsdag", :regions => [:nl]},
             {:mday => 1, :name => "Nyttårsdag", :regions => [:no]},
             {:mday => 1, :name => "Nowy Rok", :regions => [:pl]},
-            {:function => "pl_trzech_kroli(year)", :function_arguments => [:year], :name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
-            {:function => "pl_trzech_kroli_informal(year)", :function_arguments => [:year], :type => :informal, :name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
+            {:mday => 6, :year_ranges => { :from => 2011 },:name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
+            {:mday => 6, :year_ranges => { :until => 2010 },:type => :informal, :name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
             {:mday => 21, :type => :informal, :name => "Dzień Babci", :regions => [:pl]},
             {:mday => 22, :type => :informal, :name => "Dzień Dziadka", :regions => [:pl]},
             {:mday => 1, :name => "Ano Novo", :regions => [:pt]},
@@ -627,14 +627,6 @@ when 2028
   # Event's period/next year is known, but precise dates aren't.
   # Previously, dates were announced 2 years ahead, so on ~2026-05 this method would need to be revisited.
 end
-},
-
-"pl_trzech_kroli(year)" => Proc.new { |year|
-year >= 2011 ? 6 : nil
-},
-
-"pl_trzech_kroli_informal(year)" => Proc.new { |year|
-year < 2011 ? 6 : nil
 },
 
 

--- a/lib/generated_definitions/lu.rb
+++ b/lib/generated_definitions/lu.rb
@@ -14,7 +14,7 @@ module Holidays
       {
                 0 => [{:function => "easter(year)", :function_arguments => [:year], :function_modifier => 1, :name => "Ouschterméindeg", :regions => [:lu]},
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 39, :name => "Christi Himmelfaart", :regions => [:lu]},
-            {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 49, :name => "Péngschtméindeg", :regions => [:lu]}],
+            {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 50, :name => "Péngschtméindeg", :regions => [:lu]}],
       1 => [{:mday => 1, :name => "Neijoerschdag", :regions => [:lu]}],
       5 => [{:mday => 1, :name => "Dag vun der Aarbecht", :regions => [:lu]},
             {:mday => 9, :year_ranges => { :from => 2019 },:name => "Europadag", :regions => [:lu]}],

--- a/lib/generated_definitions/nz.rb
+++ b/lib/generated_definitions/nz.rb
@@ -32,7 +32,7 @@ module Holidays
       10 => [{:wday => 1, :week => 1, :observed => "previous_friday(date)", :observed_arguments => [:date], :name => "Hawke's bay Anniversary Day", :regions => [:nz_hb]},
             {:wday => 1, :week => 4, :name => "Labour Day", :regions => [:nz]},
             {:wday => 1, :week => 4, :observed => "next_week(date)", :observed_arguments => [:date], :name => "Marlborough Anniversary Day", :regions => [:nz_mb]}],
-      11 => [{:wday => 5, :week => 2, :name => "Canterbury Anniversary Day", :regions => [:nz_ca]},
+      11 => [{:function => "nz_canterbury_anniversary(year)", :function_arguments => [:year], :name => "Canterbury Anniversary Day", :regions => [:nz_ca]},
             {:mday => 30, :observed => "closest_monday(date)", :observed_arguments => [:date], :name => "Chatham Island Anniversary Day", :regions => [:nz_ch]}],
       12 => [{:mday => 1, :observed => "closest_monday(date)", :observed_arguments => [:date], :name => "Westland Anniversary Day", :regions => [:nz_wl]},
             {:mday => 25, :observed => "to_monday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:nz]},
@@ -58,6 +58,14 @@ date - 3
 },
 
 "next_week(date)" => Proc.new { |date|
+date + 7
+},
+
+"nz_canterbury_anniversary(year)" => Proc.new { |year|
+date = Date.civil(year, 11, 1)
+date += 1 until date.tuesday?
+date += 1
+date += 1 until date.friday?
 date + 7
 },
 

--- a/lib/generated_definitions/pl.rb
+++ b/lib/generated_definitions/pl.rb
@@ -24,8 +24,8 @@ module Holidays
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 49, :name => "Zesłanie Ducha Świętego (Zielone Świątki)", :regions => [:pl]},
             {:function => "easter(year)", :function_arguments => [:year], :function_modifier => 60, :name => "Uroczystość Najświętszego Ciała i Krwi Pańskiej (Boże Ciało)", :regions => [:pl]}],
       1 => [{:mday => 1, :name => "Nowy Rok", :regions => [:pl]},
-            {:function => "pl_trzech_kroli(year)", :function_arguments => [:year], :name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
-            {:function => "pl_trzech_kroli_informal(year)", :function_arguments => [:year], :type => :informal, :name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
+            {:mday => 6, :year_ranges => { :from => 2011 },:name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
+            {:mday => 6, :year_ranges => { :until => 2010 },:type => :informal, :name => "Objawienie Pańskie (święto Trzech Króli)", :regions => [:pl]},
             {:mday => 21, :type => :informal, :name => "Dzień Babci", :regions => [:pl]},
             {:mday => 22, :type => :informal, :name => "Dzień Dziadka", :regions => [:pl]}],
       2 => [{:mday => 2, :type => :informal, :name => "Ofiarowanie Pańskie (Matki Boskiej Gromnicznej)", :regions => [:pl]},
@@ -58,15 +58,7 @@ module Holidays
 
     def self.custom_methods
       {
-          "pl_trzech_kroli(year)" => Proc.new { |year|
-year >= 2011 ? 6 : nil
-},
-
-"pl_trzech_kroli_informal(year)" => Proc.new { |year|
-year < 2011 ? 6 : nil
-},
-
-
+          
       }
     end
   end

--- a/lib/holidays/version.rb
+++ b/lib/holidays/version.rb
@@ -1,3 +1,3 @@
 module Holidays
-  VERSION = '9.2.0'
+  VERSION = '10.0.0'
 end

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -229,5 +229,23 @@ assert_equal "King's Birthday", (Holidays.on(Date.civil(2023, 9, 25), [:au_wa])[
 
     assert_equal "Reconciliation Day", (Holidays.on(Date.civil(2025, 6, 2), [:au_act])[0] || {})[:name]
 
+    assert_equal "May Public Holiday", (Holidays.on(Date.civil(2004, 5, 17), [:au_sa])[0] || {})[:name]
+
+    assert_equal "March Public Holiday", (Holidays.on(Date.civil(2006, 3, 13), [:au_sa])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2006, 5, 15), [:au_sa])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2011, 10, 3), [:au_qld])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2013, 5, 6), [:au_qld])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2013, 11, 14), [:au_qld_brisbane])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2015, 5, 4), [:au_qld])[0] || {})[:name]
+
+    assert_nil (Holidays.on(Date.civil(2016, 6, 13), [:au_qld])[0] || {})[:name]
+
+    assert_equal "King's Birthday", (Holidays.on(Date.civil(2024, 10, 7), [:au_qld])[0] || {})[:name]
+
   end
 end

--- a/test/defs/test_defs_europe.rb
+++ b/test/defs/test_defs_europe.rb
@@ -1136,6 +1136,8 @@ assert_equal "Vecgada diena", (Holidays.on(Date.civil(2029, 12, 31), [:lv])[0] |
 
     assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2011, 1, 6), [:pl])[0] || {})[:name]
 
+    assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2011, 1, 6), [:pl], [:informal])[0] || {})[:name]
+
     assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2012, 1, 6), [:pl])[0] || {})[:name]
 
     assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2013, 1, 6), [:pl])[0] || {})[:name]

--- a/test/defs/test_defs_lu.rb
+++ b/test/defs/test_defs_lu.rb
@@ -23,7 +23,7 @@ class LuDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "Stiefesdag", (Holidays.on(Date.civil(2008, 12, 26), [:lu], [:informal])[0] || {})[:name]
 
-    assert_equal "Péngschtméindeg", (Holidays.on(Date.civil(2008, 5, 11), [:lu], [:informal])[0] || {})[:name]
+    assert_equal "Péngschtméindeg", (Holidays.on(Date.civil(2008, 5, 12), [:lu], [:informal])[0] || {})[:name]
 
     assert_equal "Dag vun der Aarbecht", (Holidays.on(Date.civil(2019, 5, 1), [:lu])[0] || {})[:name]
 

--- a/test/defs/test_defs_nz.rb
+++ b/test/defs/test_defs_nz.rb
@@ -63,5 +63,11 @@ class NzDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "King's Birthday", (Holidays.on(Date.civil(2023, 6, 5), [:nz])[0] || {})[:name]
 
+    assert_equal "Canterbury Anniversary Day", (Holidays.on(Date.civil(2023, 11, 17), [:nz_ca])[0] || {})[:name]
+
+    assert_equal "Canterbury Anniversary Day", (Holidays.on(Date.civil(2024, 11, 15), [:nz_ca])[0] || {})[:name]
+
+    assert_equal "Canterbury Anniversary Day", (Holidays.on(Date.civil(2028, 11, 17), [:nz_ca])[0] || {})[:name]
+
   end
 end

--- a/test/defs/test_defs_pl.rb
+++ b/test/defs/test_defs_pl.rb
@@ -109,6 +109,8 @@ class PlDefinitionTests < Test::Unit::TestCase  # :nodoc:
 
     assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2011, 1, 6), [:pl])[0] || {})[:name]
 
+    assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2011, 1, 6), [:pl], [:informal])[0] || {})[:name]
+
     assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2012, 1, 6), [:pl])[0] || {})[:name]
 
     assert_equal "Objawienie Pańskie (święto Trzech Króli)", (Holidays.on(Date.civil(2013, 1, 6), [:pl])[0] || {})[:name]


### PR DESCRIPTION
Major release.

* Drop support for Ruby 3.2. Supported versions are now 3.3, 3.4, 4.0, and ruby-head ([endoflife.date/ruby](https://endoflife.date/ruby) lists 3.2 as EOL).
* Update to [v7.0.0 definitions](https://github.com/holidays/definitions/releases/tag/v7.0.0).
* Bump tested JRuby from 10.0.4.0 to 10.0.5.0.
* Raise an `ArgumentError` during definition parsing when a `function` or `observed` rule references an unknown method (#333).
* Fix bug (#352) where holidays with the same name and region that differed only by their function modifier were merged into a single entry, dropping one of the dates.
* Document that `tests` stanzas in custom definition files loaded via `load_custom` are not run at runtime (#304).

Bumps `lib/holidays/version.rb` to 10.0.0, raises `required_ruby_version` to `>= 3.3`, updates the CI matrix and README, advances the `definitions` submodule to v7.0.0, and regenerates the affected definition files.