### PR TITLE
Ignore AI tool local work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,17 @@ Gemfile.lock
 .bundle
 reports/
 coverage/
+
+# Beads / Dolt files (added by bd init)
+.beads/
+.dolt/
+*.db
+.beads-credential-key
+
+# Beads orchestration
+.worktrees/
+
+# Claude / local agent protocol (kept local, never committed)
+.claude/
+CLAUDE.md
+AGENTS.md


### PR DESCRIPTION
We are agnostic about AI usage as defined by [this](https://github.com/holidays/holidays/blob/master/AI_POLICY.md).

We want to ignore any contributions for common tools. If you use this locally then we will not know, all we see is the human user submission.