### PR TITLE
Pre-stage :vn alongside :vi in lunar calendar map (#177)

### DIFF
--- a/lib/holidays/date_calculator/lunar_date.rb
+++ b/lib/holidays/date_calculator/lunar_date.rb
@@ -501,6 +501,9 @@ module Holidays
       CALENDAR_YEAR_INFO_MAP = {
         kr: KOREAN_LUNAR_YEAR_INFO,
         vi: VIETNAMESE_LUNAR_YEAR_INFO,
+        # vn is the ISO 3166-1 code for Vietnam; kept alongside the legacy vi key
+        # until the breaking vi -> vn rename lands. See definitions issue #177.
+        vn: VIETNAMESE_LUNAR_YEAR_INFO,
         hk: CHINESE_LUNAR_YEAR_INFO,
       }.freeze
 

--- a/test/holidays/date_calculator/test_lunar_date.rb
+++ b/test/holidays/date_calculator/test_lunar_date.rb
@@ -86,4 +86,10 @@ class LunarHolidaysCalculatorTests < Test::Unit::TestCase
     assert_equal '2017-04-06', @subject.to_solar(2017,3,10, :vi).to_s
     assert_equal '2018-03-27', @subject.to_solar(2018,3,10, :vi).to_s
   end
+
+  def test_hung_kings_festival_resolves_for_vn_region
+    assert_equal '2014-04-09', @subject.to_solar(2014,3,10, :vn).to_s
+    assert_equal '2017-04-06', @subject.to_solar(2017,3,10, :vn).to_s
+    assert_equal '2018-03-27', @subject.to_solar(2018,3,10, :vn).to_s
+  end
 end


### PR DESCRIPTION
Groundwork for the Vietnam region code rename `:vi` -> `:vn` ([definitions #177](https://github.com/holidays/definitions/issues/177)).

Adds `vn: VIETNAMESE_LUNAR_YEAR_INFO` alongside the existing `vi:` key in `CALENDAR_YEAR_INFO_MAP`. This is **non-breaking and inert today** (no `vn` region exists yet), but it lets the lunar `lunar_to_solar` calculation resolve once the definitions repo renames Vietnam to `vn`.

Why now: the definitions PR [holidays/definitions#341](https://github.com/holidays/definitions/pull/341) renames `vi.yaml` -> `vn.yaml`, and its downstream contract test (which clones this repo's master) fails until master knows `:vn`. Merging this unblocks that check.

The legacy `:vi` key is removed later in the breaking major release that bumps the definitions submodule.

Test added: `to_solar(..., :vn)` resolves the Hung Kings Festival dates identically to `:vi`.