### PR TITLE
Parse region_names in definition parser

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -98,7 +98,8 @@ namespace :generate do
       puts "Building #{region} definition module:"
       files = files.collect { |f| "#{DEFINITION_PATH}/#{f}" }.uniq
 
-      regions, rules_by_month, custom_methods, tests = Holidays::Factory::Definition.file_parser.parse_definition_files(files)
+      regions, rules_by_month, custom_methods, tests, region_names = Holidays::Factory::Definition.file_parser.parse_definition_files(files)
+      _ = region_names # consumed by REGION_NAMES generation in a later step
       module_src, test_src = Holidays::Factory::Definition.source_generator.generate_definition_source(region, files, regions, rules_by_month, custom_methods, tests)
 
       File.open("lib/#{Holidays::DEFINITIONS_PATH}/#{region.downcase.to_s}.rb","w") do |file|

--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -90,7 +90,7 @@ module Holidays
     end
 
     def load_custom(*files)
-      regions, rules_by_month, custom_methods, _ = Factory::Definition.file_parser.parse_definition_files(files)
+      regions, rules_by_month, custom_methods, _, _ = Factory::Definition.file_parser.parse_definition_files(files)
 
       # Capture source code before converting entities to Procs so the merger
       # can detect genuine conflicts (same name, different logic).

--- a/lib/holidays/definition/context/generator.rb
+++ b/lib/holidays/definition/context/generator.rb
@@ -27,6 +27,7 @@ module Holidays
           all_rules_by_month = {}
           all_custom_methods = {}
           all_tests = []
+          all_region_names = {}
 
           files.flatten!
 
@@ -51,11 +52,19 @@ module Holidays
             all_custom_methods.merge!(custom_methods)
 
             all_tests += @test_parser.call(definition_file['tests'])
+
+            region_names = definition_file['region_names']
+            if region_names
+              symbolized_region_names = region_names.each_with_object({}) do |(region, name), hash|
+                hash[region.to_sym] = name
+              end
+              all_region_names.merge!(symbolized_region_names)
+            end
           end
 
           all_regions.flatten!.uniq!
 
-          [all_regions, all_rules_by_month, all_custom_methods, all_tests]
+          [all_regions, all_rules_by_month, all_custom_methods, all_tests, all_region_names]
         end
 
         def generate_definition_source(module_name, files, regions, rules_by_month, custom_methods, tests)

--- a/test/data/test_region_names_one_defs.yaml
+++ b/test/data/test_region_names_one_defs.yaml
@@ -1,0 +1,16 @@
+months:
+  6:
+  - name: Region Names One
+    regions: [region_names_one]
+    mday: 1
+
+region_names:
+  region_names_one: 'Region Names One'
+  region_names_one_sub: 'Region Names One Sub'
+
+tests:
+  - given:
+      date: '2013-06-01'
+      regions: [region_names_one]
+    expect:
+      name: "Region Names One"

--- a/test/data/test_region_names_two_defs.yaml
+++ b/test/data/test_region_names_two_defs.yaml
@@ -1,0 +1,15 @@
+months:
+  6:
+  - name: Region Names Two
+    regions: [region_names_two]
+    mday: 2
+
+region_names:
+  region_names_two: 'Region Names Two'
+
+tests:
+  - given:
+      date: '2013-06-02'
+      regions: [region_names_two]
+    expect:
+      name: "Region Names Two"

--- a/test/holidays/definition/context/test_generator.rb
+++ b/test/holidays/definition/context/test_generator.rb
@@ -120,6 +120,47 @@ class GeneratorTests < Test::Unit::TestCase
     assert_equal ["parsed tests"], parsed_tests
   end
 
+  def test_parse_definition_files_correctly_parse_region_names
+    files = ['test/data/test_region_names_one_defs.yaml']
+    @custom_method_parser.expects(:call).with(nil).returns({})
+    @test_parser.stubs(:call).returns([])
+
+    region_names = @generator.parse_definition_files(files)[4]
+
+    expected_region_names = {
+      :region_names_one     => 'Region Names One',
+      :region_names_one_sub => 'Region Names One Sub',
+    }
+
+    assert_equal expected_region_names, region_names
+  end
+
+  def test_parse_definition_files_merges_region_names_across_multiple_files
+    files = ['test/data/test_region_names_one_defs.yaml', 'test/data/test_region_names_two_defs.yaml']
+    @custom_method_parser.expects(:call).with(nil).twice.returns({})
+    @test_parser.stubs(:call).returns([])
+
+    region_names = @generator.parse_definition_files(files)[4]
+
+    expected_region_names = {
+      :region_names_one     => 'Region Names One',
+      :region_names_one_sub => 'Region Names One Sub',
+      :region_names_two     => 'Region Names Two',
+    }
+
+    assert_equal expected_region_names, region_names
+  end
+
+  def test_parse_definition_files_returns_empty_region_names_when_absent
+    files = ['test/data/test_single_custom_holiday_defs.yaml']
+    @custom_method_parser.expects(:call).with(nil).returns({})
+    @test_parser.stubs(:call).returns([])
+
+    region_names = @generator.parse_definition_files(files)[4]
+
+    assert_equal({}, region_names)
+  end
+
   def test_generate_definition_source_correctly_generate_module_src
     files = ['test/data/test_single_custom_holiday_defs.yaml']
     @custom_method_parser.expects(:call).with(nil).returns({})


### PR DESCRIPTION
Threads the `region_names` data (added by definitions PR #325) through the definition parser, as the first code-side step toward exposing human-readable region names.

## Changes
- `generator.rb#parse_definition_files`: reads `definition_file['region_names']` (guarded for absence), symbolizes keys (values stay strings), merges across files, and returns a 5-tuple appending `region_names`.
- `lib/holidays.rb` `load_custom`: absorbs the new tuple element (does not need names).
- `Rakefile` `generate:definitions`: captures `region_names` for downstream consumption.

## Scope / non-breaking
- No public API change. Generated output is untouched (REGION_NAMES generation is a separate follow-up).

## Tests
- New cases in `test/holidays/definition/context/test_generator.rb`: single-file parse, merge across files (symbol keys / string values), and absence of `region_names` returns an empty hash without crashing.
- Full `rake test`: 480 tests, 0 failures.