### PR TITLE
Fix silent cache miss when regions passed as strings (#357)

### DIFF
--- a/lib/holidays/definition/repository/cache.rb
+++ b/lib/holidays/definition/repository/cache.rb
@@ -10,17 +10,19 @@ module Holidays
           raise ArgumentError unless cache_data
           raise ArgumentError unless start_date && end_date
 
-          @cache_range[options] = start_date..end_date
-          @cache[options] = cache_data.group_by { |holiday| holiday[:date] }
+          key = normalize(options)
+          @cache_range[key] = start_date..end_date
+          @cache[key] = cache_data.group_by { |holiday| holiday[:date] }
         end
 
         def find(start_date, end_date, options)
           return nil unless in_cache_range?(start_date, end_date, options)
 
+          key = normalize(options)
           if start_date == end_date
-            @cache[options].fetch(start_date, [])
+            @cache[key].fetch(start_date, [])
           else
-            @cache[options].select do |date, holidays|
+            @cache[key].select do |date, holidays|
               date >= start_date && date <= end_date
             end.flat_map { |date, holidays| holidays }
           end
@@ -33,8 +35,12 @@ module Holidays
 
         private
 
+        def normalize(options)
+          Array(options).flatten.map(&:to_sym).uniq.sort
+        end
+
         def in_cache_range?(start_date, end_date, options)
-          range = @cache_range[options]
+          range = @cache_range[normalize(options)]
           if range
             range.begin <= start_date && range.end >= end_date
           else

--- a/test/holidays/definition/repository/test_cache.rb
+++ b/test/holidays/definition/repository/test_cache.rb
@@ -108,6 +108,36 @@ class CacheRepoTests < Test::Unit::TestCase
     end
   end
 
+  def test_entry_stored_with_symbol_regions_is_found_with_string_regions
+    start_date = Date.civil(2015, 1, 1)
+    end_date = Date.civil(2015, 7, 1)
+    cache_data = [{:date=>Date.civil(2015, 1, 1), :name=>"New Year's Day", :regions=>[:us]}]
+
+    @subject.cache_between(start_date, end_date, cache_data, [:us])
+
+    assert_equal(cache_data, @subject.find(start_date, end_date, ["us"]))
+  end
+
+  def test_reordered_regions_hit_the_same_cached_entry
+    start_date = Date.civil(2015, 1, 1)
+    end_date = Date.civil(2015, 7, 1)
+    cache_data = [{:date=>Date.civil(2015, 1, 1), :name=>"New Year's Day", :regions=>[:us]}]
+
+    @subject.cache_between(start_date, end_date, cache_data, [:us, :ca])
+
+    assert_equal(cache_data, @subject.find(start_date, end_date, [:ca, :us]))
+  end
+
+  def test_duplicate_regions_hit_the_same_cached_entry
+    start_date = Date.civil(2015, 1, 1)
+    end_date = Date.civil(2015, 7, 1)
+    cache_data = [{:date=>Date.civil(2015, 1, 1), :name=>"New Year's Day", :regions=>[:us]}]
+
+    @subject.cache_between(start_date, end_date, cache_data, [:us])
+
+    assert_equal(cache_data, @subject.find(start_date, end_date, [:us, :us]))
+  end
+
   def test_reset_clears_cache
     start_date = Date.civil(2015, 1, 1)
     end_date = Date.civil(2015, 1, 1)


### PR DESCRIPTION
Fixes #357.

## Problem
`Holidays.between` keys the cache on the raw, un-normalized options array. The lookup path symbolizes regions (`ParseOptions#parse_regions!` does `collect(&:to_sym)`), but the cache does not, so `cache_between(:us)` stores under `[:us]` while `between("us")` looks up `["us"]` and silently misses, recomputing on every call. Region order and duplicates break the key too.

## Fix
`cache.rb` derives a canonical key via a private `normalize(options) = Array(options).flatten.map(&:to_sym).uniq.sort`, applied in `cache_between`, `find`, and `in_cache_range?`. Cached data and public signatures unchanged; only the key is normalized.

Makes the cache insensitive to string-vs-symbol regions, region order, and duplicates.

## Tests
- New cases in `test/holidays/definition/repository/test_cache.rb`: symbol-stored entry found via string regions; reordered and duplicate regions hit the same entry; existing behavior preserved.
- Full `rake test`: 480 tests, 0 failures.