### PR TITLE
Restrict irb and rdoc dev deps to MRI platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'irb'
-  gem 'rdoc'
+  # MRI only: rdoc pulls in rbs, whose native extension cannot build on JRuby.
+  # Both gems exist to silence warnings and are not needed to run the suite.
+  gem 'irb', platform: :mri
+  gem 'rdoc', platform: :mri
 end


### PR DESCRIPTION
Fixes the `jruby-10.0.5.0` matrix leg, which is currently red on master and on every open PR.

## The failure

The job dies in the `Set up Ruby` step during `bundle install`, before any test runs:

```
An error occurred while installing rbs (4.0.3), and Bundler cannot continue.

In Gemfile:
  irb was resolved to 1.18.0, which depends on
    rdoc was resolved to 8.0.0, which depends on
      rbs
```

## Root cause

`Gemfile.lock` is gitignored, so CI resolves dependencies fresh on every run, and the development group pins nothing. rdoc 8.0.0 (released 2026-06-26) added a dependency on `rbs`, and rbs ships a native extension that cannot build on a JVM.

Master's last green run was 2026-06-11, two weeks before rdoc 8.0.0 shipped, so the breakage has gone unnoticed until now. This is not caused by any recent change: a clean clone of master tip `4821b3a` with no lockfile reproduces the identical error under `jruby -S bundle install`.

## The fix

`irb` and `rdoc` were added in f2e2bf2 solely to silence warnings, and neither is needed to run the suite. Restricting them to MRI keeps the warnings quiet where it matters and takes JRuby off the rbs path entirely.

Alternatives considered: pinning `rdoc < 8.0.0` defers the problem and rots; dropping JRuby from the matrix loses real coverage.

## Testing

Verified locally on JRuby 10.0.4.0 and MRI 4.0.2 (a clean `bundle install` on both, no lockfile):

- JRuby: `bundle install` succeeds; suite 483 tests, 8516 assertions, 0 failures
- MRI: suite 483 tests, 8516 assertions, 0 failures