### PR TITLE
Add Holidays.region_names and Holidays.region_name to public API

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -89,6 +89,14 @@ module Holidays
       Holidays::REGIONS
     end
 
+    def region_names
+      Holidays::REGION_NAMES
+    end
+
+    def region_name(region)
+      Holidays::REGION_NAMES[region]
+    end
+
     def load_custom(*files)
       regions, rules_by_month, custom_methods, _, _ = Factory::Definition.file_parser.parse_definition_files(files)
 

--- a/test/smoke/test_region_names.rb
+++ b/test/smoke/test_region_names.rb
@@ -1,0 +1,44 @@
+# encoding: utf-8
+require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
+
+class RegionNamesTests < Test::Unit::TestCase
+  def test_region_names_returns_hash
+    assert Holidays.region_names.is_a?(Hash)
+  end
+
+  def test_region_names_returns_symbol_keys_and_string_values
+    Holidays.region_names.each do |region, name|
+      assert region.is_a?(Symbol)
+      assert name.is_a?(String)
+    end
+  end
+
+  def test_region_names_returns_the_full_map
+    assert_equal(Holidays::REGION_NAMES, Holidays.region_names)
+  end
+
+  def test_region_names_covers_every_available_region
+    missing = Holidays.available_regions - Holidays.region_names.keys
+    assert_equal([], missing)
+  end
+
+  def test_region_name_returns_english_name_for_region
+    assert_equal("England", Holidays.region_name(:gb_eng))
+  end
+
+  def test_region_name_returns_name_for_parent_region
+    assert_equal("United Kingdom", Holidays.region_name(:gb))
+  end
+
+  def test_region_name_handles_yaml_reserved_region
+    assert_equal("Norway", Holidays.region_name(:no))
+  end
+
+  def test_region_name_returns_nil_for_unknown_region
+    assert_nil(Holidays.region_name(:nonsense))
+  end
+
+  def test_region_name_returns_nil_for_nil
+    assert_nil(Holidays.region_name(nil))
+  end
+end


### PR DESCRIPTION
Part of #160 (getting the name of a region). Follows #479, which generated the central `REGION_NAMES` map, and #481, which completed it.

## What this does

Exposes the `REGION_NAMES` map through the public API with two accessors, mirroring how `available_regions` exposes `REGIONS`:

```ruby
Holidays.region_names        # => {:ar => "Argentina", :at => "Austria", ...}
Holidays.region_name(:gb_eng) # => "England"
Holidays.region_name(:no)     # => "Norway"
Holidays.region_name(:nope)   # => nil
```

`region_name` returns `nil` for an unknown region rather than raising. These are lookups, not searches: `available_regions` is a plain accessor that validates nothing, whereas the `ArgumentError` boundary checks in `between`/`next_holidays`/`year_holidays` guard search arguments. `nil` also suits the use case in #160, building a list of selectable regions for a user.

`available_regions` is unchanged, so this is purely additive.

## Testing

`test/smoke/test_region_names.rb`, alongside the existing `test_available_regions.rb`. 9 tests covering:

- `region_names` returns a hash of symbol keys and string values, equal to `Holidays::REGION_NAMES`
- every entry in `available_regions` has a name (guards against a region shipping without one)
- `region_name(:gb_eng)` and `region_name(:gb)` return the expected English names
- `region_name(:no)` returns `"Norway"`, covering the YAML-reserved key that could otherwise resolve to `false`
- `region_name` returns `nil` for an unknown symbol and for `nil`

Full suite: 495 tests, 9110 assertions, 0 failures, 0 errors. Line coverage 90.84%.

## Note

This does not close #160 on its own. The issue's second ask, that `gb_con` (Cornwall) does not inherit England's holidays, remains outstanding and is tracked separately.