### PR TITLE
Document region names API and bump to 11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Ruby Holidays Gem CHANGELOG
 
+## 11.1.0
+
+* Add `Holidays.region_names` and `Holidays.region_name(region)` to expose the English name of each region ([#160](https://github.com/holidays/holidays/issues/160)). Names are the ISO 3166 English short names added in [definitions #325](https://github.com/holidays/definitions/pull/325). `region_name` returns `nil` for an unknown region. `available_regions` is unchanged.
+* Update to [v8.0.1 definitions](https://github.com/holidays/definitions/releases/tag/v8.0.1). Please see the changelog for the definition details.
+* Fix `gb` Christmas and Boxing Day observed dates when Christmas falls on a Sunday ([#396](https://github.com/holidays/holidays/issues/396)). Boxing Day is now observed on Monday the 26th and Christmas Day is substituted to Tuesday the 27th. Callers matching on holiday name will see these two names swap for the affected dates.
+* Fix `ph` National Heroes Day when August 31st falls on a Sunday ([definitions issue-345](https://github.com/holidays/definitions/issues/345))
+
 ## 11.0.0
 
 * Update to [v8.0.0 definitions](https://github.com/holidays/definitions/releases/tag/v8.0.0). Please see the changelog for the definition details.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,31 @@ Holidays.available_regions
 => [:ar, :at, ..., :sg] # this will be a big array
 ```
 
+#### Return region names
+
+Return the English name of every region:
+
+```ruby
+Holidays.region_names
+=> {:ar=>"Argentina", :at=>"Austria", ..., :sg=>"Singapore"} # this will be a big hash
+```
+
+Return the English name of a single region:
+
+```ruby
+Holidays.region_name(:gb_eng)
+=> "England"
+```
+
+Unknown regions return `nil`:
+
+```ruby
+Holidays.region_name(:not_a_region)
+=> nil
+```
+
+Names are the [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) English short names where one exists. Subregions and non-country regions (stock exchanges, central banks, shipping carriers) use their common English name.
+
 ## Loading Custom Definitions on the fly
 
 In addition to the [provided definitions](https://github.com/holidays/definitions) you can load custom definitions file on the fly and use them immediately.

--- a/lib/holidays/version.rb
+++ b/lib/holidays/version.rb
@@ -1,3 +1,3 @@
 module Holidays
-  VERSION = '11.0.0'
+  VERSION = '11.1.0'
 end


### PR DESCRIPTION
Completes the region names work: #479 generated the `REGION_NAMES` map, #482 exposed it through the public API, #481 and #483 brought in and tagged the supporting definitions. This documents it and cuts the version.

> [!IMPORTANT]
> Merging this publishes holidays 11.1.0 to RubyGems. `release.yml` runs on every successful master build, reads `VERSION` from `version.rb`, and pushes the gem if that version is not already published. There is no manual approval step.

## Changes

- `CHANGELOG.md`: new `## 11.1.0` section
- `lib/holidays/version.rb`: `11.0.0` -> `11.1.0`
- `README.md`: a "Return region names" section after "Return all available regions"

## Why minor

The API additions are backwards compatible and `available_regions` is untouched. The v8.0.1 definitions do change existing output, though, so the CHANGELOG calls that out explicitly rather than leaving it to the definitions changelog: when Christmas falls on a Sunday, `gb` Christmas Day and Boxing Day swap which observed date carries which name. Anyone matching on holiday name for those dates sees different results. That is a fix for [#396](https://github.com/holidays/holidays/issues/396), not a new feature, so a minor bump rather than major.

## Verification

- Full suite: 495 tests, 9110 assertions, 0 failures, 0 errors. Line coverage 90.84%.
- Every README example was run and its output copied from the real result, including `region_names` ordering, `region_name(:gb_eng)` => `"England"`, and `region_name(:not_a_region)` => `nil`.
- Simulated `changelog-check` locally: `version.rb` and the top CHANGELOG heading both read 11.1.0, so both of its conditions pass.

## Note

This does not close [#160](https://github.com/holidays/holidays/issues/160). The issue's second ask, that `gb_con` (Cornwall) does not inherit England's holidays, is still outstanding and tracked separately.