### PR TITLE
Point definitions submodule at holidays/definitions instead of a fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "definitions"]
 	path = definitions
-	url = https://github.com/jlsync/definitions
+	url = https://github.com/holidays/definitions


### PR DESCRIPTION
## Problem

`.gitmodules` on `master` declares:

```
[submodule "definitions"]
	path = definitions
	url = https://github.com/jlsync/definitions
```

The official source is `https://github.com/holidays/definitions`. `CONTRIBUTING.md` instructs contributors to run `git clone --recursive git@github.com/holidays/holidays` and documents the definitions as living in `holidays/definitions`, so anyone following those instructions has their local submodule config populated from a personal fork instead.

Introduced by 5319a90 (2025-11-28), which flipped the url from `holidays/definitions`. This appears to be a development convenience that was merged and not reverted. The same pattern occurred in 0f27ee5 (2018, `ppeble/definitions`, restored by 30be7b9) and 05797cb (2022, `n-studio/definitions`).

## Scope

Only fresh recursive clones are affected. Git copies the `.gitmodules` url into local `.git/config` once at submodule init and reads local config thereafter, so existing checkouts that initialized before 5319a90 still point at `holidays/definitions`.

Released gems are not affected: the gemspec packages `git ls-files lib` plus CHANGELOG/LICENSE/README, so only the precompiled `lib/generated_definitions/` ships. No submodule, `.gitmodules`, or YAML is included in the gem.

## Change

One line in `.gitmodules`, url `jlsync/definitions` -> `holidays/definitions`, followed by `git submodule sync`.

The pinned commit is deliberately unchanged.

## Verification

- Pin unchanged at `b564bab` (`git ls-tree HEAD -- definitions`); the diff is `.gitmodules` only.
- `b564bab` is HEAD, `refs/heads/master`, and `refs/tags/v8.0.1` on `holidays/definitions`. `jlsync/definitions` master is a different commit (`ffc6cfd`), so the pin had no fork-only dependency.
- A fresh `git submodule update --init` using the new url clones and checks out exactly `b564bab` (v8.0.1).
- `rake test`: 495 tests, 9110 assertions, 0 failures, 0 errors.

Note that `make update-defs` (`git submodule update --init --remote`) follows the default branch rather than the pin, so it now tracks `holidays/definitions` master. That is currently a no-op since upstream master is `b564bab`.

A follow-up adding a CI guard against this recurring is in progress.