### PR TITLE
Add CI guard requiring definitions submodule to track holidays/definitions master

### DIFF
--- a/.github/workflows/definitions-submodule-check.yml
+++ b/.github/workflows/definitions-submodule-check.yml
@@ -1,0 +1,58 @@
+name: Definitions Submodule Check
+on:
+  pull_request:
+    branches: ["master"]
+  push:
+    branches: ["master"]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
+      - name: Verify definitions submodule points at holidays/definitions master
+        run: |
+          EXPECTED_URL="https://github.com/holidays/definitions"
+          FAILED=false
+
+          URL=$(git config -f .gitmodules --get submodule.definitions.url || true)
+          echo ".gitmodules url: ${URL:-<unset>}"
+          if [ "$URL" != "$EXPECTED_URL" ]; then
+            echo "ERROR: .gitmodules declares definitions url '${URL:-<unset>}' but must be ${EXPECTED_URL}"
+            FAILED=true
+          fi
+
+          BRANCH=$(git config -f .gitmodules --get submodule.definitions.branch || true)
+          if [ -n "$BRANCH" ]; then
+            echo "ERROR: .gitmodules declares 'branch = ${BRANCH}' for definitions; the submodule must pin a commit, not track a branch"
+            FAILED=true
+          fi
+
+          PIN=$(git ls-tree HEAD -- definitions | awk '{print $3}')
+          echo "pinned commit: ${PIN:-<none>}"
+          if [ -z "$PIN" ]; then
+            echo "ERROR: no gitlink entry for definitions found in the tree"
+            FAILED=true
+          else
+            git init -q defs-check
+            git -C defs-check remote add origin "$EXPECTED_URL"
+            if ! git -C defs-check fetch -q --filter=blob:none origin master; then
+              echo "ERROR: could not fetch master from ${EXPECTED_URL}"
+              FAILED=true
+            elif ! git -C defs-check cat-file -e "${PIN}^{commit}" 2>/dev/null; then
+              echo "ERROR: pinned commit ${PIN} does not exist in ${EXPECTED_URL}; it looks like a fork-only or unmerged commit"
+              FAILED=true
+            elif ! git -C defs-check merge-base --is-ancestor "$PIN" FETCH_HEAD; then
+              echo "ERROR: pinned commit ${PIN} exists in ${EXPECTED_URL} but is not reachable from master; master must never pin a side branch or unmerged PR head"
+              FAILED=true
+            fi
+            rm -rf defs-check
+          fi
+
+          if [ "$FAILED" = "true" ]; then
+            echo ""
+            echo "The definitions submodule on master must point at ${EXPECTED_URL} and pin a commit that is on its master branch."
+            echo "See CONTRIBUTING.md: use 'make point-to-defs-master' locally, and never merge a fork or branch pointer."
+            exit 1
+          fi
+
+          echo "OK: definitions points at ${EXPECTED_URL} and pin ${PIN} is on master"


### PR DESCRIPTION
Follow-up to #485.

## Why

The definitions submodule url on `master` has drifted to a personal fork three times:

- 0f27ee5 (2018, `ppeble/definitions`, reverted by 30be7b9)
- 05797cb (2022, `n-studio/definitions`)
- 5319a90 (2025-11-28, `jlsync/definitions`, fixed by #485 after roughly 8 months undetected)

Nothing catches this today. The pinned commit is typically still a legitimate upstream commit, so the definition data is identical and the whole test suite stays green. Only the provenance is wrong, and there is no check for provenance.

## What this adds

`.github/workflows/definitions-submodule-check.yml`, running on pull requests targeting `master` and on pushes to `master`. It fails when any of the following hold:

1. the `.gitmodules` url for `definitions` is not exactly `https://github.com/holidays/definitions`
2. `.gitmodules` declares a `branch =` key for `definitions` (the submodule must pin a commit, not track a branch)
3. the pinned gitlink commit is not reachable from `holidays/definitions` master

Check 3 is the substantive one. It catches pinning a fork-only commit, a side branch, or an unmerged PR head, none of which the url check alone would detect. It shallow-fetches `master` from the definitions repo with `--filter=blob:none`, distinguishes "commit absent entirely" from "commit present but not on master", and reports each with its own message.

The workflow follows the shape of `changelog-check.yml`: same trigger style, pinned action SHA, explicit `ERROR:` lines accumulated into a single `exit 1`.

## Verification

The script logic was exercised locally against four cases:

| case | result |
|---|---|
| pre-#485 tree (`jlsync` url, valid pin) | fails on url, exit 1 |
| post-#485 tree (correct url and pin) | passes, exit 0 |
| pin set to a nonexistent sha | fails with "does not exist" |
| pin set to `ffc6cfd` (`jlsync` HEAD) | passes |

The last case is correct rather than a gap: `ffc6cfd` is an ancestor of `holidays/definitions` master, 92 commits behind it, so the fork carries no commits upstream lacks. That is a stale pin, not a provenance problem, and the url check catches the fork pointer regardless.

This branch is rebased on master with #485 merged, so its own run of the new workflow exercises the passing path.