### PR TITLE
Register sg in lunar calendar map so Singapore can use Chinese lunar dates

### DIFF
--- a/lib/holidays/date_calculator/lunar_date.rb
+++ b/lib/holidays/date_calculator/lunar_date.rb
@@ -502,6 +502,7 @@ module Holidays
         kr: KOREAN_LUNAR_YEAR_INFO,
         vn: VIETNAMESE_LUNAR_YEAR_INFO,
         hk: CHINESE_LUNAR_YEAR_INFO,
+        sg: CHINESE_LUNAR_YEAR_INFO,
       }.freeze
 
       # Provides number of days per lunar month type.  Lunar months

--- a/test/holidays/date_calculator/test_lunar_date.rb
+++ b/test/holidays/date_calculator/test_lunar_date.rb
@@ -86,4 +86,18 @@ class LunarHolidaysCalculatorTests < Test::Unit::TestCase
     assert_equal '2017-04-06', @subject.to_solar(2017,3,10, :vn).to_s
     assert_equal '2018-03-27', @subject.to_solar(2018,3,10, :vn).to_s
   end
+
+  def test_chinese_new_year_returns_expected_results_for_singapore
+    assert_equal '2014-01-31', @subject.to_solar(2014,1,1, :sg).to_s
+    assert_equal '2018-02-16', @subject.to_solar(2018,1,1, :sg).to_s
+    assert_equal '2021-02-12', @subject.to_solar(2021,1,1, :sg).to_s
+    assert_equal '2023-01-22', @subject.to_solar(2023,1,1, :sg).to_s
+    assert_equal '2026-02-17', @subject.to_solar(2026,1,1, :sg).to_s
+  end
+
+  def test_second_day_of_chinese_new_year_returns_expected_results_for_singapore
+    assert_equal '2014-02-01', @subject.to_solar(2014,1,2, :sg).to_s
+    assert_equal '2023-01-23', @subject.to_solar(2023,1,2, :sg).to_s
+    assert_equal '2026-02-18', @subject.to_solar(2026,1,2, :sg).to_s
+  end
 end


### PR DESCRIPTION
Unblocks holidays/definitions#338, which has been failing its downstream check since 2026-05-22.

## Problem

`sg.yaml` in definitions#338 computes Chinese New Year with `lunar_to_solar(year, month, day, region)`. In this gem, `lunar_date.rb:11` looks the region up in `CALENDAR_YEAR_INFO_MAP`, which registers only `kr`, `vn` and `hk`:

```ruby
CALENDAR_YEAR_INFO_MAP = {
  kr: KOREAN_LUNAR_YEAR_INFO,
  vn: VIETNAMESE_LUNAR_YEAR_INFO,
  hk: CHINESE_LUNAR_YEAR_INFO,
}.freeze
```

For `:sg` the lookup returns `nil`, and line 14 dereferences it immediately:

```
NoMethodError: undefined method '[]' for nil
  lib/holidays/date_calculator/lunar_date.rb:14:in 'block in to_solar'
```

That takes out `test_defs_sg` and four smoke tests that iterate every region.

Worth noting why this stayed hidden for two months: all four of the definitions repo's own Ruby jobs pass, because nothing there exercises this calculator. Only the downstream "Ruby (holidays)" check sees it.

## Change

Register `sg` against the existing Chinese table. Singapore observes the same Chinese lunar calendar as Hong Kong, so no new data is needed:

```ruby
sg: CHINESE_LUNAR_YEAR_INFO,
```

Plus unit tests for Singapore Chinese New Year and its second day. `test_lunar_date.rb` previously covered only `kr` and `vn`; `hk`, and therefore the Chinese table itself, had no direct coverage at all.

## Verification

Written test-first. Both new tests fail on master with the exact production error above, and pass with the one-line change.

- `test_lunar_date.rb`: 6 tests, 76 assertions, 0 failures
- `rake test`: 497 tests, 9118 assertions, 0 failures, 0 errors
- `rake test:contract`: 99 tests, 7914 assertions, 0 failures, 0 errors
- against definitions#338 rebased onto definitions master: contract suite goes from 4 failures / 2 errors to 99 tests, 8008 assertions, 0 failures, 0 errors

Expected dates were cross-checked against the existing `hk` table, which reproduces the real Chinese New Year dates for 2014-2026 (2014-01-31, 2015-02-19, 2016-02-08, 2017-01-28, 2018-02-16, 2019-02-05, 2020-01-25, 2021-02-12, 2022-02-01, 2023-01-22, 2024-02-10, 2025-01-29, 2026-02-17).

## Merge order

This needs to land here first. The "Ruby (holidays)" check on definitions#338 clones this repo's master, so #338 stays red until this is merged.