### PR TITLE
Create the git tag and GitHub release when publishing a gem version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [completed]
     branches: ["master"]
 permissions:
-  contents: read
+  contents: write
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -47,3 +47,37 @@ jobs:
           gem build holidays.gemspec
           gem push "holidays-${VERSION}.gem"
           echo "Successfully published holidays ${VERSION} to RubyGems"
+      # Runs regardless of whether this job published, so a version that reached
+      # RubyGems without a tag is healed on the next run rather than staying
+      # untagged forever.
+      - name: Create git tag and GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v${VERSION}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists, nothing to do"
+            exit 0
+          fi
+
+          # The release notes are the CHANGELOG section for this version. Its
+          # absence means the CHANGELOG was not updated, which Changelog Check
+          # should already have caught, so fail rather than publish empty notes.
+          NOTES=$(awk -v ver="## ${VERSION}" '
+            $0 == ver { found = 1; next }
+            /^## / { if (found) exit }
+            found { print }
+          ' CHANGELOG.md | sed '/^$/d')
+
+          if [ -z "$NOTES" ]; then
+            echo "ERROR: no '## ${VERSION}' section found in CHANGELOG.md"
+            exit 1
+          fi
+
+          gh release create "$TAG" \
+            --target "${{ github.event.workflow_run.head_sha }}" \
+            --title "$TAG" \
+            --notes "$NOTES"
+          echo "Created ${TAG} at ${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
## Why

`release.yml` publishes the gem to RubyGems but never creates a git tag or GitHub release. As a result every version from 9.1.0 through 11.2.0 shipped untagged: RubyGems had 8 versions the repository had no ref for, so `git diff v11.0.0..v11.1.0` was impossible and no version had release notes.

I backfilled those 8 tags and releases by hand today. This change stops the gap from reopening on the next release.

## What changes

Adds a `Create git tag and GitHub release` step after publishing, and raises `permissions: contents` from `read` to `write` so the workflow can create the ref.

The step:

- Tags `v${VERSION}` at `github.event.workflow_run.head_sha`, the master commit the Ruby workflow succeeded on, matching where the existing tags point (the release PR's merge commit).
- Uses the matching `## ${VERSION}` section of `CHANGELOG.md` as the release notes.
- Exits early if the release already exists, so re-runs are safe.
- Deliberately runs even when the publish step was skipped, so a version that reached RubyGems without a tag gets healed on the next run rather than staying untagged forever.
- Fails loudly if `CHANGELOG.md` has no section for the version, rather than publishing an empty release. `Changelog Check` should already prevent that, so reaching this branch means something upstream went wrong.

## Verification

- Workflow YAML parses; step order and `permissions: contents: write` confirmed.
- The CHANGELOG extraction was run against the real file: 11.2.0 returns its 4 bullets, 9.1.1 its single bullet, and a nonexistent version returns empty, which is what triggers the guard.