### PR TITLE
Pass declared arguments to observed methods in declared order

### DIFF
--- a/lib/holidays/definition/context/function_processor.rb
+++ b/lib/holidays/definition/context/function_processor.rb
@@ -35,30 +35,19 @@ module Holidays
           raise ArgumentError if desired_func_args.include?(:region) && !input[:region].is_a?(Symbol)
         end
 
+        # Arguments are supplied in the order the definition declares them. The proc
+        # is built with that same declared order, so anything else silently binds
+        # values to the wrong parameters.
         def parse_arguments(input, target_args)
-          args = []
-
-          if target_args.include?(:year)
-            args << input[:year]
+          target_args.map do |arg|
+            case arg
+            when :year   then input[:year]
+            when :month  then input[:month]
+            when :day    then input[:day]
+            when :date   then Date.civil(input[:year], input[:month], input[:day])
+            when :region then input[:region]
+            end
           end
-
-          if target_args.include?(:month)
-            args << input[:month]
-          end
-
-          if target_args.include?(:day)
-            args << input[:day]
-          end
-
-          if target_args.include?(:date)
-            args << Date.civil(input[:year], input[:month], input[:day])
-          end
-
-          if target_args.include?(:region)
-            args << input[:region]
-          end
-
-          args
         end
 
         def calculate(input, id, args, modifier)

--- a/lib/holidays/finder/context/search.rb
+++ b/lib/holidays/finder/context/search.rb
@@ -120,11 +120,14 @@ module Holidays
           }
         end
 
+        # Observed methods default to taking only a date, but they may declare
+        # additional arguments such as :region so that a single definition shared
+        # across regions can observe differently in one of them.
         def build_observed_date(date, regions, h)
           @custom_method_processor.call(
             build_custom_method_input(date.year, date.month, date.day, regions),
             h[:observed],
-            [:date],
+            h[:observed_arguments] || [:date],
           )
         end
       end

--- a/test/holidays/definition/context/test_function_processor.rb
+++ b/test/holidays/definition/context/test_function_processor.rb
@@ -96,6 +96,13 @@ class FunctionProcessorTests < Test::Unit::TestCase
     @subject.call(@input, @func_id, @func_args, @func_modifier)
   end
 
+  def test_args_are_passed_in_the_order_the_definition_declares_them
+    @func_args = [:region, :date]
+    @proc_result_cache_repo.expects(:lookup).at_most_once.with(@custom_func, @region, Date.civil(@year, @month, @day)).returns(Date.civil(2016, 1, 15))
+
+    @subject.call(@input, @func_id, @func_args, @func_modifier)
+  end
+
   def test_call_returns_error_if_target_function_returns_unknown_value
     @proc_result_cache_repo.expects(:lookup).at_most_once.with(@custom_func, @year).returns("bad-response")
 

--- a/test/holidays/finder/context/test_search.rb
+++ b/test/holidays/finder/context/test_search.rb
@@ -182,6 +182,25 @@ class FinderSearchTests < Test::Unit::TestCase
     )
   end
 
+  def test_passes_declared_observed_arguments_to_the_observed_function
+    @holidays_by_month_repo.expects(:find_by_month).at_most_once.returns([:mday => 8, :name => "Test", :type => :observed, :observed => "SOME_OBSERVED_FUNC_ID", :observed_arguments => [:date, :region], :regions=>@regions])
+
+    @custom_method_processor.expects(:call).with(
+      {:year => 2015, :month => 1, :day => 8, :region => :us},
+      "SOME_OBSERVED_FUNC_ID",
+      [:date, :region],
+    ).returns(Date.civil(2015, 10, 1))
+
+    assert_equal(
+      [{
+        :date => Date.civil(2015, 10, 1),
+        :name => "Test",
+        :regions => [:us],
+      }],
+      @subject.call(@dates_driver, @regions, [:observed])
+    )
+  end
+
   def test_returns_unobserved_date_if_observed_method_not_set_but_flag_is_present
     @holidays_by_month_repo.expects(:find_by_month).at_most_once.returns([:mday => 14, :name => "Test", :type => :observed, :observed => "SOME_OBSERVED_FUNC_ID", :regions=>@regions])
 


### PR DESCRIPTION
Fixes #433, and unblocks the Utah Juneteenth definition merged in definitions#290, which currently crashes the downstream contract tests.

Two problems, both in how custom method arguments are supplied.

**Observed methods never received their declared arguments.** `build_observed_date` hardcoded `[:date]`, so a definition declaring `region` got nothing. The generator already emits `:observed_arguments` alongside `:observed`, so this just reads what was already there.

**Argument order was ignored.** `parse_arguments` built the argument array through five sequential `if`s in a fixed order (year, month, day, date, region), while `CustomMethodProc` builds the proc using the order the definition declares. Any declaration not written in that exact fixed order silently bound values to the wrong parameters. It now maps over the declared arguments in order.

Together these make `us.yaml`'s `juneteenth_national_independence_day(date, region)` with `arguments: region, date` behave as written, with no change needed in the definitions repo.

## Safety of the ordering change

I checked every `arguments:` declaration across all definition files and `METHODS.yml`: 86 in total, of which exactly one is not already in canonical order, and that one is the new `region, date` from definitions#290. For the other 85 the produced array is byte identical, so this is a no-op everywhere except the case that is currently broken.

## Testing

Full suite passes: 499 tests, 9302 assertions, 0 failures.

Two new unit tests cover the specific behaviour: that declared observed arguments are forwarded, and that arguments are passed in declared order.

Verified end to end against definitions master with `us.yaml` untouched. Contract tests go from 1 failure and 2 errors to 99 tests, 8089 assertions, 0 failures, and the previously failing `test_observed_flag_does_not_raise_for_any_region` smoke test passes. Utah resolves correctly:

```
      Jun19    us_ut        us
2024  Wed      2024-06-17   2024-06-19
2025  Thu      2025-06-16   2025-06-19
2026  Fri      2026-06-15   2026-06-19
2027  Sat      2027-06-21   2027-06-18
2028  Mon      2028-06-19   2028-06-19
2033  Sun      2033-06-20   2033-06-20
```

Before this fix, `Holidays.on` with `:observed` raised `NoMethodError: undefined method 'wday' for nil` for any June 19 lookup in `us` and `northamerica`, not just Utah.
