### PR TITLE
Reconcile native jp/tr custom methods with definitions master

### DIFF
--- a/lib/holidays/definition/custom_methods/jp.rb
+++ b/lib/holidays/definition/custom_methods/jp.rb
@@ -94,7 +94,9 @@ module Holidays
             # This suuuucks. I have no idea how to make this not reach into our interal ruby API to do this.
             # I'm punting, I'll come back to this.
             is_holiday = Holidays::JP.holidays_by_month[date.month].any? do |holiday|
-              holiday[:mday] == date.day
+              next false unless holiday[:mday] == date.day
+              next true unless holiday[:year_ranges]
+              Holidays::Finder::Rules::YearRange.call(date.year, holiday[:year_ranges])
             end
             date.wday == 0 || is_holiday ? (Holidays::Factory::Definition.custom_methods_repository.find("jp_next_weekday(date)").call(date+1)) : date
           end

--- a/lib/holidays/definition/custom_methods/tr.rb
+++ b/lib/holidays/definition/custom_methods/tr.rb
@@ -15,7 +15,17 @@ module Holidays
                 '2017' => Date.civil(2017, 6, 25),
                 '2018' => Date.civil(2018, 6, 15),
                 '2019' => Date.civil(2019, 6, 4),
-                '2020' => Date.civil(2020, 5, 24)
+                '2020' => Date.civil(2020, 5, 24),
+                '2021' => Date.civil(2021, 5, 13),
+                '2022' => Date.civil(2022, 5, 2),
+                '2023' => Date.civil(2023, 4, 21),
+                '2024' => Date.civil(2024, 4, 10),
+                '2025' => Date.civil(2025, 3, 30),
+                '2026' => Date.civil(2026, 3, 20),
+                '2027' => Date.civil(2027, 3, 9),
+                '2028' => Date.civil(2028, 2, 26),
+                '2029' => Date.civil(2029, 2, 15),
+                '2030' => Date.civil(2030, 2, 4)
             }
             begin_of_ramadan_feast[year.to_s]
           end
@@ -28,7 +38,17 @@ module Holidays
                 '2017' => Date.civil(2017, 9, 1),
                 '2018' => Date.civil(2018, 8, 21),
                 '2019' => Date.civil(2019, 8, 11),
-                '2020' => Date.civil(2020, 7, 31)
+                '2020' => Date.civil(2020, 7, 31),
+                '2021' => Date.civil(2021, 7, 20),
+                '2022' => Date.civil(2022, 7, 9),
+                '2023' => Date.civil(2023, 6, 28),
+                '2024' => Date.civil(2024, 6, 16),
+                '2025' => Date.civil(2025, 6, 6),
+                '2026' => Date.civil(2026, 5, 27),
+                '2027' => Date.civil(2027, 5, 16),
+                '2028' => Date.civil(2028, 5, 5),
+                '2029' => Date.civil(2029, 4, 24),
+                '2030' => Date.civil(2030, 4, 13)
             }
             begin_of_sacrifice_feast[year.to_s]
           end


### PR DESCRIPTION
The native ports in #498 were taken from the pinned submodule (v8.2.0).
holidays/definitions master has since changed three of them, so the def tests
fail once holidays/definitions#382 drops the YAML fallback.

- JP.jp_next_weekday: add the year_ranges guard inside the holiday match
  (definitions 3c89c13).
- TR.ramadan_feast, TR.sacrifice_feast: add the 2021-2030 lookup entries.
