### PR TITLE
Populate observed_arguments in the shared definition parse path

### DIFF
--- a/lib/holidays/definition/context/generator.rb
+++ b/lib/holidays/definition/context/generator.rb
@@ -132,6 +132,10 @@ module Holidays
                     rule[:function_arguments] = get_function_arguments(rule[:function], parsed_custom_methods)
                   end
 
+                  if rule[:observed]
+                    rule[:observed_arguments] = get_function_arguments(rule[:observed], parsed_custom_methods)
+                  end
+
                   rules_by_month[month] << rule
                 end
               end

--- a/test/integration/data/test_custom_observed_with_arguments_defs.yaml
+++ b/test/integration/data/test_custom_observed_with_arguments_defs.yaml
@@ -1,0 +1,25 @@
+months:
+  6:
+  - name: Custom Observed Holiday
+    regions: [custom_observed_with_args]
+    mday: 19
+    observed: custom_move_if_weekend(region, date)
+methods:
+  custom_move_if_weekend:
+    arguments: region, date
+    ruby: |
+      if region == :custom_observed_with_args && date.saturday?
+        date + 2
+      elsif date.sunday?
+        date + 1
+      else
+        date
+      end
+
+tests:
+  - given:
+      date: '2021-06-21'
+      regions: [custom_observed_with_args]
+      options: [observed]
+    expect:
+      name: "Custom Observed Holiday"

--- a/test/integration/test_custom_observed_with_arguments.rb
+++ b/test/integration/test_custom_observed_with_arguments.rb
@@ -1,0 +1,19 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
+
+# Regression test: load_custom must populate :observed_arguments for observed
+# methods that take arguments other than 'date'. Before the fix, the parse path
+# only set :function_arguments, so build_observed_date fell back to [:date] and
+# called a multi-argument observed proc with a single argument, raising
+# NoMethodError.
+class CustomObservedWithArgumentsTest < Test::Unit::TestCase
+  def setup
+    Holidays.load_custom('test/integration/data/test_custom_observed_with_arguments_defs.yaml')
+  end
+
+  def test_observed_method_with_region_and_date_arguments_resolves
+    # 2021-06-19 is a Saturday, so the observed date moves to Monday the 21st.
+    holidays = Holidays.on(Date.civil(2021, 6, 21), :custom_observed_with_args, [:observed])
+
+    assert_equal "Custom Observed Holiday", (holidays[0] || {})[:name]
+  end
+end


### PR DESCRIPTION
load_custom never set :observed_arguments, so an observed method taking
arguments other than date was called with a single argument and raised
NoMethodError. The shared parse path now resolves :observed_arguments the same
way it already resolves :function_arguments; the pre-compiled generator path was
already correct, so generated definitions are unchanged.
