### PR TITLE
Rename Holidays::LoadAllDefinitions to a private Holidays::Bootstrap

### DIFF
--- a/lib/holidays.rb
+++ b/lib/holidays.rb
@@ -7,7 +7,7 @@ require 'holidays/factory/definition'
 require 'holidays/factory/date_calculator'
 require 'holidays/factory/finder'
 require 'holidays/errors'
-require 'holidays/load_all_definitions'
+require 'holidays/bootstrap'
 
 module Holidays
   WEEKS = {:first => 1, :second => 2, :third => 3, :fourth => 4, :fifth => 5, :last => -1, :second_last => -2, :third_last => -3}
@@ -140,4 +140,6 @@ module Holidays
   end
 end
 
-Holidays::LoadAllDefinitions.call
+module Holidays
+  Bootstrap.call
+end

--- a/lib/holidays/bootstrap.rb
+++ b/lib/holidays/bootstrap.rb
@@ -1,16 +1,16 @@
 require 'holidays/definition/custom_methods/registry'
 
 module Holidays
-  #TODO This file should be renamed. It's no longer about definitions, really.
-  class LoadAllDefinitions
+  # Runs once at require time (see the bottom of lib/holidays.rb). Despite the
+  # historical name of its alias, this does NOT load per-region holiday data;
+  # that happens lazily in Definition::Context::Load. What it does:
+  #   1. Register the built-in calculation procs (easter, weekend modifiers,
+  #      lunar_to_solar, calculate_day_of_month) into custom_methods_repository.
+  #   2. Register the native per-region custom methods (CustomMethods.all).
+  #   3. Require generated_definitions/REGIONS.rb (the region-name list only).
+  class Bootstrap
     class << self
       def call
-        #FIXME I need a better way to do this. I'm thinking of putting these 'common' methods
-        # into some kind of definition file so it can be loaded automatically but I'm afraid
-        # of making that big of a breaking API change since these are public. For the time
-        # being I'll load them manually like this.
-        #
-        # NOTE: These are no longer public! We can do whatever we want here!
         global_methods = {
           "easter(year)" => gregorian_easter.method(:calculate_easter_for).to_proc,
           "orthodox_easter(year)" => gregorian_easter.method(:calculate_orthodox_easter_for).to_proc,
@@ -61,4 +61,6 @@ module Holidays
       end
     end
   end
+
+  private_constant :Bootstrap
 end

--- a/lib/holidays/definition/custom_methods/registry.rb
+++ b/lib/holidays/definition/custom_methods/registry.rb
@@ -25,7 +25,7 @@ module Holidays
       # Maps the full call-signature string used by YAML +function:+/+observed:+
       # references to the native proc that implements it. Seeded into
       # Factory::Definition.custom_methods_repository at boot by
-      # LoadAllDefinitions.call, alongside the global built-in methods.
+      # Holidays::Bootstrap.call, alongside the global built-in methods.
       #
       # Native replacement for the old per-region +methods:/ruby:+ YAML blocks.
       # No eval, no public registration API.

--- a/test/e2e/test_all_regions.rb
+++ b/test/e2e/test_all_regions.rb
@@ -1,10 +1,6 @@
 require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
 
 class AllRegionsTests < Test::Unit::TestCase
-  def setup
-    Holidays::LoadAllDefinitions.call
-  end
-
   def test_definition_dir
     assert File.directory?(Holidays::FULL_DEFINITIONS_PATH)
   end

--- a/test/holidays/test_bootstrap.rb
+++ b/test/holidays/test_bootstrap.rb
@@ -1,0 +1,16 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
+
+require 'holidays'
+
+class BootstrapTests < Test::Unit::TestCase
+  def test_builtin_global_methods_are_registered_at_boot
+    repo = Holidays::Factory::Definition.custom_methods_repository
+
+    assert_not_nil repo.find("easter(year)")
+    assert_not_nil repo.find("lunar_to_solar(year, month, day, region)")
+  end
+
+  def test_bootstrap_is_not_publicly_accessible
+    assert_raise(NameError) { Holidays::Bootstrap }
+  end
+end


### PR DESCRIPTION
The class never loaded definition data. It registers the built-in calculation
procs and the native per-region custom methods at require time, then requires
REGIONS.rb. Renamed to Holidays::Bootstrap and made a private constant, with the
call site moved to module scope.

LoadAllDefinitions was undocumented and already marked non-public in the code,
and nothing referenced it outside the boot call, so it's removed rather than
aliased. Stale TODO/FIXME comments dropped. Closes #497.
