### PR TITLE
Calculate tr Ramazan and Kurban Bayramı from a Hijri calendar

### DIFF
--- a/lib/holidays/date_calculator/hijri_date.rb
+++ b/lib/holidays/date_calculator/hijri_date.rb
@@ -1,0 +1,52 @@
+require 'date'
+
+module Holidays
+  module DateCalculator
+    # Arithmetic ("tabular", a.k.a. Kuwaiti) Islamic calendar.
+    #
+    # Months alternate 30 and 29 days; leap years add a day to the twelfth
+    # month on a fixed 11-of-30 cycle. This is a purely arithmetic calendar,
+    # so it can land a day (occasionally two) either side of a locally
+    # proclaimed date. Callers that need the proclaimed date layer their own
+    # override table on top of this (see
+    # Holidays::Definition::CustomMethods::TR).
+    class HijriDate
+      # Julian day number of 1 Muharram 1 AH minus one day, chosen so that
+      # to_jd's month/day terms are added directly. Corresponds to the civil
+      # epoch (Friday, 16 July 622 CE proleptic Julian).
+      EPOCH_JDN = 1948439
+
+      def to_gregorian(hijri_year, hijri_month, hijri_day)
+        Date.jd(to_jd(hijri_year, hijri_month, hijri_day))
+      end
+
+      # Given a Gregorian year and a fixed Hijri month/day, return the
+      # occurrence that falls within that Gregorian year, or nil if none does.
+      #
+      # A fixed Hijri date drifts ~11 days earlier each Gregorian year, so
+      # roughly once every 33 years it falls twice in the same Gregorian year
+      # (once in early January, once in late December). Only the earlier
+      # occurrence is returned.
+      def gregorian_year_occurrence(gregorian_year, hijri_month, hijri_day)
+        candidate_hijri_year = gregorian_year - 579
+
+        (candidate_hijri_year - 1..candidate_hijri_year + 1).each do |hijri_year|
+          date = to_gregorian(hijri_year, hijri_month, hijri_day)
+          return date if date.year == gregorian_year
+        end
+
+        nil
+      end
+
+      private
+
+      def to_jd(year, month, day)
+        day +
+          (29.5 * (month - 1)).ceil +
+          (year - 1) * 354 +
+          (3 + 11 * year) / 30 +
+          EPOCH_JDN
+      end
+    end
+  end
+end

--- a/lib/holidays/definition/custom_methods/tr.rb
+++ b/lib/holidays/definition/custom_methods/tr.rb
@@ -3,54 +3,63 @@ require 'date'
 module Holidays
   module Definition
     module CustomMethods
-      # tr custom holiday calculations, ported verbatim from the
-      # +methods:+ block in definitions/tr.yaml.
+      # tr custom holiday calculations.
+      #
+      # Ramazan Bayramı is 1 Shawwal and Kurban Bayramı is 10 Dhul-Hijjah of
+      # the Hijri calendar. Both are derived from the arithmetic Islamic
+      # calendar (Holidays::DateCalculator::HijriDate). The civil holidays are
+      # proclaimed by Türkiye's Diyanet and in most years so far have landed a
+      # day (2016 Ramazan Bayramı, two days) before the arithmetic result;
+      # DIYANET_OVERRIDES pins those years to the proclaimed date. Years with
+      # no entry fall back to the calculation. See definitions#377.
       module TR
+        SHAWWAL = 10
+        DHU_AL_HIJJAH = 12
+
+        # Proclaimed first days that differ from the arithmetic calendar,
+        # keyed by [feast, gregorian_year]. Sourced from the Diyanet dates
+        # that the definition file previously carried as a fixed table, plus
+        # https://vakithesaplama.diyanet.gov.tr/resmitatiller.php for 2021-2030.
+        DIYANET_OVERRIDES = {
+          [:ramadan_feast, 2014] => Date.new(2014, 7, 28),
+          [:ramadan_feast, 2015] => Date.new(2015, 7, 17),
+          [:ramadan_feast, 2016] => Date.new(2016, 7, 5),
+          [:ramadan_feast, 2017] => Date.new(2017, 6, 25),
+          [:ramadan_feast, 2019] => Date.new(2019, 6, 4),
+          [:ramadan_feast, 2022] => Date.new(2022, 5, 2),
+          [:ramadan_feast, 2023] => Date.new(2023, 4, 21),
+          [:ramadan_feast, 2025] => Date.new(2025, 3, 30),
+          [:ramadan_feast, 2027] => Date.new(2027, 3, 9),
+          [:ramadan_feast, 2028] => Date.new(2028, 2, 26),
+          [:ramadan_feast, 2030] => Date.new(2030, 2, 4),
+
+          [:sacrifice_feast, 2014] => Date.new(2014, 10, 4),
+          [:sacrifice_feast, 2016] => Date.new(2016, 9, 12),
+          [:sacrifice_feast, 2017] => Date.new(2017, 9, 1),
+          [:sacrifice_feast, 2018] => Date.new(2018, 8, 21),
+          [:sacrifice_feast, 2019] => Date.new(2019, 8, 11),
+          [:sacrifice_feast, 2022] => Date.new(2022, 7, 9),
+          [:sacrifice_feast, 2023] => Date.new(2023, 6, 28),
+          [:sacrifice_feast, 2024] => Date.new(2024, 6, 16),
+          [:sacrifice_feast, 2025] => Date.new(2025, 6, 6),
+          [:sacrifice_feast, 2027] => Date.new(2027, 5, 16),
+          [:sacrifice_feast, 2030] => Date.new(2030, 4, 13),
+        }.freeze
+
         class << self
           def ramadan_feast(year)
-            begin_of_ramadan_feast = {
-                '2014' => Date.civil(2014, 7, 28),
-                '2015' => Date.civil(2015, 7, 17),
-                '2016' => Date.civil(2016, 7, 5),
-                '2017' => Date.civil(2017, 6, 25),
-                '2018' => Date.civil(2018, 6, 15),
-                '2019' => Date.civil(2019, 6, 4),
-                '2020' => Date.civil(2020, 5, 24),
-                '2021' => Date.civil(2021, 5, 13),
-                '2022' => Date.civil(2022, 5, 2),
-                '2023' => Date.civil(2023, 4, 21),
-                '2024' => Date.civil(2024, 4, 10),
-                '2025' => Date.civil(2025, 3, 30),
-                '2026' => Date.civil(2026, 3, 20),
-                '2027' => Date.civil(2027, 3, 9),
-                '2028' => Date.civil(2028, 2, 26),
-                '2029' => Date.civil(2029, 2, 15),
-                '2030' => Date.civil(2030, 2, 4)
-            }
-            begin_of_ramadan_feast[year.to_s]
+            feast(:ramadan_feast, year, SHAWWAL, 1)
           end
 
           def sacrifice_feast(year)
-            begin_of_sacrifice_feast = {
-                '2014' => Date.civil(2014, 10, 4),
-                '2015' => Date.civil(2015, 9, 24),
-                '2016' => Date.civil(2016, 9, 12),
-                '2017' => Date.civil(2017, 9, 1),
-                '2018' => Date.civil(2018, 8, 21),
-                '2019' => Date.civil(2019, 8, 11),
-                '2020' => Date.civil(2020, 7, 31),
-                '2021' => Date.civil(2021, 7, 20),
-                '2022' => Date.civil(2022, 7, 9),
-                '2023' => Date.civil(2023, 6, 28),
-                '2024' => Date.civil(2024, 6, 16),
-                '2025' => Date.civil(2025, 6, 6),
-                '2026' => Date.civil(2026, 5, 27),
-                '2027' => Date.civil(2027, 5, 16),
-                '2028' => Date.civil(2028, 5, 5),
-                '2029' => Date.civil(2029, 4, 24),
-                '2030' => Date.civil(2030, 4, 13)
-            }
-            begin_of_sacrifice_feast[year.to_s]
+            feast(:sacrifice_feast, year, DHU_AL_HIJJAH, 10)
+          end
+
+          private
+
+          def feast(name, year, hijri_month, hijri_day)
+            DIYANET_OVERRIDES[[name, year]] ||
+              Holidays::Factory::DateCalculator.hijri_date.gregorian_year_occurrence(year, hijri_month, hijri_day)
           end
         end
       end

--- a/lib/holidays/factory/date_calculator.rb
+++ b/lib/holidays/factory/date_calculator.rb
@@ -2,6 +2,7 @@ require 'holidays/date_calculator/easter'
 require 'holidays/date_calculator/weekend_modifier'
 require 'holidays/date_calculator/day_of_month'
 require 'holidays/date_calculator/lunar_date'
+require 'holidays/date_calculator/hijri_date'
 
 module Holidays
   module Factory
@@ -25,8 +26,12 @@ module Holidays
       end
 
       class << self
-        def lunar_date 
+        def lunar_date
           Holidays::DateCalculator::LunarDate.new
+        end
+
+        def hijri_date
+          Holidays::DateCalculator::HijriDate.new
         end
 
         def weekend_modifier

--- a/test/holidays/date_calculator/test_hijri_date.rb
+++ b/test/holidays/date_calculator/test_hijri_date.rb
@@ -1,0 +1,28 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../../test_helper'
+
+require 'holidays/date_calculator/hijri_date.rb'
+
+class HijriDateCalculatorTests < Test::Unit::TestCase
+  def setup
+    @subject = Holidays::DateCalculator::HijriDate.new
+  end
+
+  def test_to_gregorian_converts_known_reference_dates
+    assert_equal '2014-10-25', @subject.to_gregorian(1436, 1, 1).to_s
+    assert_equal '2019-05-06', @subject.to_gregorian(1440, 9, 1).to_s
+    assert_equal '2023-04-22', @subject.to_gregorian(1444, 10, 1).to_s
+    assert_equal '2025-06-07', @subject.to_gregorian(1446, 12, 10).to_s
+    assert_equal '2033-04-01', @subject.to_gregorian(1455, 1, 1).to_s
+  end
+
+  def test_gregorian_year_occurrence_returns_the_date_in_that_year
+    assert_equal '2023-04-22', @subject.gregorian_year_occurrence(2023, 10, 1).to_s
+    assert_equal '2032-01-14', @subject.gregorian_year_occurrence(2032, 10, 1).to_s
+    assert_equal '2031-04-03', @subject.gregorian_year_occurrence(2031, 12, 10).to_s
+  end
+
+  def test_gregorian_year_occurrence_returns_the_earlier_of_two_in_one_year
+    # 1 Shawwal falls on both 2033-01-03 and 2033-12-23.
+    assert_equal '2033-01-03', @subject.gregorian_year_occurrence(2033, 10, 1).to_s
+  end
+end

--- a/test/holidays/definition/custom_methods/test_tr.rb
+++ b/test/holidays/definition/custom_methods/test_tr.rb
@@ -1,0 +1,46 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../../../test_helper'
+
+require 'holidays/definition/custom_methods/tr'
+
+# Regression anchor for definitions#377: every date the tr definition file
+# previously carried as a fixed table must still be produced, now from the
+# arithmetic calendar plus DIYANET_OVERRIDES. Years past the old table are
+# covered too, to prove the holidays no longer silently disappear.
+class TRCustomMethodsTests < Test::Unit::TestCase
+  RAMADAN_FEAST = {
+    2014 => '2014-07-28', 2015 => '2015-07-17', 2016 => '2016-07-05',
+    2017 => '2017-06-25', 2018 => '2018-06-15', 2019 => '2019-06-04',
+    2020 => '2020-05-24', 2021 => '2021-05-13', 2022 => '2022-05-02',
+    2023 => '2023-04-21', 2024 => '2024-04-10', 2025 => '2025-03-30',
+    2026 => '2026-03-20', 2027 => '2027-03-09', 2028 => '2028-02-26',
+    2029 => '2029-02-15', 2030 => '2030-02-04', 2031 => '2031-01-25',
+    2032 => '2032-01-14'
+  }.freeze
+
+  SACRIFICE_FEAST = {
+    2014 => '2014-10-04', 2015 => '2015-09-24', 2016 => '2016-09-12',
+    2017 => '2017-09-01', 2018 => '2018-08-21', 2019 => '2019-08-11',
+    2020 => '2020-07-31', 2021 => '2021-07-20', 2022 => '2022-07-09',
+    2023 => '2023-06-28', 2024 => '2024-06-16', 2025 => '2025-06-06',
+    2026 => '2026-05-27', 2027 => '2027-05-16', 2028 => '2028-05-05',
+    2029 => '2029-04-24', 2030 => '2030-04-13', 2031 => '2031-04-03',
+    2032 => '2032-03-22'
+  }.freeze
+
+  def test_ramadan_feast_matches_the_diyanet_dates
+    RAMADAN_FEAST.each do |year, expected|
+      assert_equal expected, Holidays::Definition::CustomMethods::TR.ramadan_feast(year).to_s
+    end
+  end
+
+  def test_sacrifice_feast_matches_the_diyanet_dates
+    SACRIFICE_FEAST.each do |year, expected|
+      assert_equal expected, Holidays::Definition::CustomMethods::TR.sacrifice_feast(year).to_s
+    end
+  end
+
+  def test_dates_are_still_produced_well_beyond_the_old_table
+    assert_equal '2040-10-08', Holidays::Definition::CustomMethods::TR.ramadan_feast(2040).to_s
+    assert_equal '2045-10-22', Holidays::Definition::CustomMethods::TR.sacrifice_feast(2045).to_s
+  end
+end


### PR DESCRIPTION
tr Ramazan Bayramı (1 Shawwal) and Kurban Bayramı (10 Dhul-Hijjah) were a hand-maintained year-by-year lookup that returned nil, silently dropping both holidays, for any year past the last entry.

Adds `Holidays::DateCalculator::HijriDate` (arithmetic Islamic calendar) and rewrites the two tr custom methods to use it, keeping a per-year override for the years Türkiye's Diyanet proclamation differs from the arithmetic. Dates for 2014-2030 are unchanged; later years now resolve.

Roughly once every 33 years a fixed Hijri date falls twice in one Gregorian year (Ramazan Bayramı in 2033, Kurban Bayramı in 2039); only the earlier occurrence is returned, matching the old single-date behaviour.

Pairs with definitions#385, which extends the tr tests past the old table; that PR stays red until this merges.