### PR TITLE
Fix Vietnamese lunar calendar 2017 leap month

### DIFF
--- a/lib/holidays/date_calculator/lunar_date.rb
+++ b/lib/holidays/date_calculator/lunar_date.rb
@@ -152,7 +152,7 @@ module Holidays
         [384, 1, 2, 1, 2, 1, 2, 1, 2, 4, 2, 1, 2].freeze,
         [354, 1, 2, 1, 1, 2, 1, 2, 2, 2, 1, 2, 1].freeze,
         [355, 2, 1, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2].freeze,
-        [355, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 2, 2].freeze,
+        [384, 1, 2, 1, 2, 1, 5, 1, 2, 1, 2, 2, 2].freeze, # 2017 has a leap 6th month; previous entry omitted it, shifting every later date
         [354, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2, 2].freeze,
         [354, 2, 1, 2, 1, 2, 1, 1, 2, 1, 2, 1, 2].freeze,
         [384, 2, 1, 2, 4, 2, 1, 1, 2, 1, 2, 1, 2].freeze,

--- a/test/defs/test_defs_tr.rb
+++ b/test/defs/test_defs_tr.rb
@@ -33,6 +33,8 @@ assert_equal "Ramazan Bayramı", (Holidays.on(Date.civil(2027, 3, 9), [:tr])[0] 
 assert_equal "Ramazan Bayramı", (Holidays.on(Date.civil(2028, 2, 26), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı", (Holidays.on(Date.civil(2029, 2, 15), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı", (Holidays.on(Date.civil(2030, 2, 4), [:tr])[0] || {})[:name]
+assert_equal "Ramazan Bayramı", (Holidays.on(Date.civil(2031, 1, 25), [:tr])[0] || {})[:name]
+assert_equal "Ramazan Bayramı", (Holidays.on(Date.civil(2032, 1, 14), [:tr])[0] || {})[:name]
 
     assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2017, 6, 26), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2018, 6, 16), [:tr])[0] || {})[:name]
@@ -48,6 +50,8 @@ assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2027, 3,
 assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2028, 2, 27), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2029, 2, 16), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2030, 2, 5), [:tr])[0] || {})[:name]
+assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2031, 1, 26), [:tr])[0] || {})[:name]
+assert_equal "Ramazan Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2032, 1, 15), [:tr])[0] || {})[:name]
 
     assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2017, 6, 27), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2018, 6, 17), [:tr])[0] || {})[:name]
@@ -63,6 +67,8 @@ assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2027
 assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2028, 2, 28), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2029, 2, 17), [:tr])[0] || {})[:name]
 assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2030, 2, 6), [:tr])[0] || {})[:name]
+assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2031, 1, 27), [:tr])[0] || {})[:name]
+assert_equal "Ramazan Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2032, 1, 16), [:tr])[0] || {})[:name]
 
     assert_equal "Demokrasi ve Milli Birlik Günü", (Holidays.on(Date.civil(2017, 7, 15), [:tr])[0] || {})[:name]
 
@@ -80,6 +86,8 @@ assert_equal "Kurban Bayramı", (Holidays.on(Date.civil(2027, 5, 16), [:tr])[0] 
 assert_equal "Kurban Bayramı", (Holidays.on(Date.civil(2028, 5, 5), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı", (Holidays.on(Date.civil(2029, 4, 24), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı", (Holidays.on(Date.civil(2030, 4, 13), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı", (Holidays.on(Date.civil(2031, 4, 3), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı", (Holidays.on(Date.civil(2032, 3, 22), [:tr])[0] || {})[:name]
 
     assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2017, 9, 2), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2018, 8, 22), [:tr])[0] || {})[:name]
@@ -95,6 +103,8 @@ assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2027, 5, 
 assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2028, 5, 6), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2029, 4, 25), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2030, 4, 14), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2031, 4, 4), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı (ikinci tatil)", (Holidays.on(Date.civil(2032, 3, 23), [:tr])[0] || {})[:name]
 
     assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2017, 9, 3), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2018, 8, 23), [:tr])[0] || {})[:name]
@@ -110,6 +120,8 @@ assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2027,
 assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2028, 5, 7), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2029, 4, 26), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2030, 4, 15), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2031, 4, 5), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı (üçüncü tatil)", (Holidays.on(Date.civil(2032, 3, 24), [:tr])[0] || {})[:name]
 
     assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2017, 9, 4), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2018, 8, 24), [:tr])[0] || {})[:name]
@@ -125,6 +137,8 @@ assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2027
 assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2028, 5, 8), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2029, 4, 27), [:tr])[0] || {})[:name]
 assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2030, 4, 16), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2031, 4, 6), [:tr])[0] || {})[:name]
+assert_equal "Kurban Bayramı (dördüncü tatil)", (Holidays.on(Date.civil(2032, 3, 25), [:tr])[0] || {})[:name]
 
   end
 end

--- a/test/defs/test_defs_vn.rb
+++ b/test/defs/test_defs_vn.rb
@@ -16,7 +16,10 @@ class VnDefinitionTests < Test::Unit::TestCase  # :nodoc:
     assert_equal "Quốc khánh", (Holidays.on(Date.civil(2014, 9, 2), [:vn])[0] || {})[:name]
 
     assert_equal "Giỗ tổ Hùng Vương", (Holidays.on(Date.civil(2017, 4, 6), [:vn])[0] || {})[:name]
-assert_equal "Giỗ tổ Hùng Vương", (Holidays.on(Date.civil(2018, 3, 27), [:vn])[0] || {})[:name]
+assert_equal "Giỗ tổ Hùng Vương", (Holidays.on(Date.civil(2018, 4, 25), [:vn])[0] || {})[:name]
+assert_equal "Giỗ tổ Hùng Vương", (Holidays.on(Date.civil(2019, 4, 14), [:vn])[0] || {})[:name]
+assert_equal "Giỗ tổ Hùng Vương", (Holidays.on(Date.civil(2020, 4, 2), [:vn])[0] || {})[:name]
+assert_equal "Giỗ tổ Hùng Vương", (Holidays.on(Date.civil(2023, 4, 29), [:vn])[0] || {})[:name]
 
   end
 end

--- a/test/holidays/date_calculator/test_lunar_date.rb
+++ b/test/holidays/date_calculator/test_lunar_date.rb
@@ -84,7 +84,22 @@ class LunarHolidaysCalculatorTests < Test::Unit::TestCase
     assert_equal '2015-04-28', @subject.to_solar(2015,3,10, :vn).to_s
     assert_equal '2016-04-16', @subject.to_solar(2016,3,10, :vn).to_s
     assert_equal '2017-04-06', @subject.to_solar(2017,3,10, :vn).to_s
-    assert_equal '2018-03-27', @subject.to_solar(2018,3,10, :vn).to_s
+    assert_equal '2018-04-25', @subject.to_solar(2018,3,10, :vn).to_s
+    assert_equal '2019-04-14', @subject.to_solar(2019,3,10, :vn).to_s
+    assert_equal '2020-04-02', @subject.to_solar(2020,3,10, :vn).to_s
+    assert_equal '2021-04-21', @subject.to_solar(2021,3,10, :vn).to_s
+    assert_equal '2022-04-10', @subject.to_solar(2022,3,10, :vn).to_s
+    assert_equal '2023-04-29', @subject.to_solar(2023,3,10, :vn).to_s
+    assert_equal '2024-04-18', @subject.to_solar(2024,3,10, :vn).to_s
+  end
+
+  def test_vietnamese_new_year_returns_expected_results
+    assert_equal '2017-01-28', @subject.to_solar(2017,1,1, :vn).to_s
+    assert_equal '2018-02-16', @subject.to_solar(2018,1,1, :vn).to_s
+    assert_equal '2019-02-05', @subject.to_solar(2019,1,1, :vn).to_s
+    assert_equal '2020-01-25', @subject.to_solar(2020,1,1, :vn).to_s
+    assert_equal '2021-02-12', @subject.to_solar(2021,1,1, :vn).to_s
+    assert_equal '2023-01-22', @subject.to_solar(2023,1,1, :vn).to_s
   end
 
   def test_chinese_new_year_returns_expected_results_for_singapore


### PR DESCRIPTION
The 2017 entry in `VIETNAMESE_LUNAR_YEAR_INFO` was missing that year's leap 6th month, so it was 355 days instead of 384. Because the table is a running day count, every `lunar_to_solar` result for `:vn` from mid-2017 onward was shifted about a month early. Giỗ tổ Hùng Vương 2019 came out as March 16 instead of April 14; Tết 2019 as January 7 instead of February 5.

Replaced the row with the correct leap-month entry (matching the Chinese table, which Vietnam's calendar aligns with for 2017) and added unit test coverage for 2017-2024.

Also bumps the definitions submodule to master (which now includes holidays/definitions#386, correcting the `:vn` contract test dates) and regenerates the def tests.

Fixes holidays/definitions#150