### PR TITLE
Invalidate caches when definitions are merged

### DIFF
--- a/lib/holidays/definition/context/merger.rb
+++ b/lib/holidays/definition/context/merger.rb
@@ -3,10 +3,12 @@ module Holidays
     module Context
       # Merge a new set of definitions into the Holidays module.
       class Merger
-        def initialize(holidays_by_month_repo, regions_repo, custom_methods_repo)
+        def initialize(holidays_by_month_repo, regions_repo, custom_methods_repo, cache_repo, proc_result_cache_repo)
           @holidays_repo = holidays_by_month_repo
           @regions_repo = regions_repo
           @custom_methods_repo = custom_methods_repo
+          @cache_repo = cache_repo
+          @proc_result_cache_repo = proc_result_cache_repo
         end
 
         def call(target_regions, target_holidays, target_custom_methods, target_custom_method_sources = {})
@@ -17,6 +19,9 @@ module Holidays
             target_custom_method_sources,
             derive_function_regions(target_holidays),
           )
+        ensure
+          @cache_repo.reset!
+          @proc_result_cache_repo.reset!
         end
 
         private

--- a/lib/holidays/definition/repository/proc_result_cache.rb
+++ b/lib/holidays/definition/repository/proc_result_cache.rb
@@ -33,6 +33,10 @@ module Holidays
           @proc_cache[proc_key]
         end
 
+        def reset!
+          @proc_cache = {}
+        end
+
         private
 
         def validate!(function, function_arguments)

--- a/lib/holidays/factory/definition.rb
+++ b/lib/holidays/factory/definition.rb
@@ -57,6 +57,8 @@ module Holidays
             holidays_by_month_repository,
             regions_repository,
             custom_methods_repository,
+            cache_repository,
+            proc_result_cache_repository,
           )
         end
 

--- a/test/holidays/definition/context/test_merger.rb
+++ b/test/holidays/definition/context/test_merger.rb
@@ -11,14 +11,35 @@ class MergerTests < Test::Unit::TestCase
     @holidays_repo = mock()
     @regions_repo = mock()
     @custom_methods_repo = mock()
+    @cache_repo = mock()
+    @proc_result_cache_repo = mock()
 
-    @subject = Holidays::Definition::Context::Merger.new(@holidays_repo, @regions_repo, @custom_methods_repo)
+    @subject = Holidays::Definition::Context::Merger.new(
+      @holidays_repo,
+      @regions_repo,
+      @custom_methods_repo,
+      @cache_repo,
+      @proc_result_cache_repo,
+    )
   end
 
   def test_repos_are_called_to_add_regions_and_holidays
     @holidays_repo.expects(:add).with(@target_holidays)
     @regions_repo.expects(:add).with(@target_regions)
     @custom_methods_repo.expects(:add).with(@target_custom_methods, {}, {})
+    @cache_repo.expects(:reset!)
+    @proc_result_cache_repo.expects(:reset!)
+
+    @subject.call(@target_regions, @target_holidays, @target_custom_methods)
+  end
+
+  def test_call_resets_both_caches_after_merge
+    @holidays_repo.stubs(:add)
+    @regions_repo.stubs(:add)
+    @custom_methods_repo.stubs(:add)
+
+    @cache_repo.expects(:reset!).once
+    @proc_result_cache_repo.expects(:reset!).once
 
     @subject.call(@target_regions, @target_holidays, @target_custom_methods)
   end

--- a/test/holidays/definition/context/test_merger.rb
+++ b/test/holidays/definition/context/test_merger.rb
@@ -33,14 +33,16 @@ class MergerTests < Test::Unit::TestCase
     @subject.call(@target_regions, @target_holidays, @target_custom_methods)
   end
 
-  def test_call_resets_both_caches_after_merge
-    @holidays_repo.stubs(:add)
+  def test_caches_are_still_reset_when_a_repo_raises_mid_merge
+    @holidays_repo.expects(:add).raises(StandardError, "boom")
     @regions_repo.stubs(:add)
     @custom_methods_repo.stubs(:add)
 
-    @cache_repo.expects(:reset!).once
-    @proc_result_cache_repo.expects(:reset!).once
+    @cache_repo.expects(:reset!)
+    @proc_result_cache_repo.expects(:reset!)
 
-    @subject.call(@target_regions, @target_holidays, @target_custom_methods)
+    assert_raise(StandardError) do
+      @subject.call(@target_regions, @target_holidays, @target_custom_methods)
+    end
   end
 end

--- a/test/holidays/definition/repository/test_proc_result_cache.rb
+++ b/test/holidays/definition/repository/test_proc_result_cache.rb
@@ -75,6 +75,18 @@ class ProcResultCacheRepoTests < Test::Unit::TestCase
     assert_equal(Date.civil(2016, 1, 6), @subject.lookup(function, date, modifier))
   end
 
+  def test_reset_clears_previously_cached_results
+    call_count = 0
+    function = lambda { |year| call_count += 1; Date.civil(year, 2, 1) - 1 }
+    function_argument = 2015
+
+    @subject.lookup(function, function_argument)
+    @subject.reset!
+    @subject.lookup(function, function_argument)
+
+    assert_equal(2, call_count)
+  end
+
   def test_lookup_raises_error_if_function_argument_is_not_valid
     function = lambda { |year| Date.civil(year, 2, 1) - 1 }
     function_argument = "2015"

--- a/test/integration/data/test_cache_invalidation_defs.yaml
+++ b/test/integration/data/test_cache_invalidation_defs.yaml
@@ -1,0 +1,12 @@
+months:
+  7:
+  - name: Zzz Cache Invalidation Test Day
+    regions: [de_be]
+    mday: 3
+
+tests:
+  - given:
+      date: "2025-07-03"
+      regions: ["de_be"]
+    expect:
+      name: "Zzz Cache Invalidation Test Day"

--- a/test/integration/test_cache_invalidation.rb
+++ b/test/integration/test_cache_invalidation.rb
@@ -23,4 +23,33 @@ class CacheInvalidationTest < Test::Unit::TestCase
     assert_include unscoped_names, "Zzz Cache Invalidation Test Day"
   end
 
+  # Whether a region counts as "unloaded" depends on the whole process's
+  # history (test/defs alone loads every region before test/integration
+  # runs), so this can't be driven off Factory::Definition's memoized
+  # singletons without depending on suite ordering. Build a fresh, isolated
+  # set of real (non-mocked) repos wired the same way Factory::Definition
+  # wires them, and drive Definition::Context::Load against the test_region
+  # fixture used by test_load.rb -- that exercises the real Load -> Merger
+  # -> Cache#reset! path without touching global state or actual region data.
+  def test_lazily_loading_a_new_region_also_invalidates_the_result_cache
+    cache_repo = Holidays::Definition::Repository::Cache.new
+    proc_result_cache_repo = Holidays::Definition::Repository::ProcResultCache.new
+
+    merger = Holidays::Definition::Context::Merger.new(
+      Holidays::Definition::Repository::HolidaysByMonth.new,
+      Holidays::Definition::Repository::Regions.new([], {}),
+      Holidays::Definition::Repository::CustomMethods.new,
+      cache_repo,
+      proc_result_cache_repo,
+    )
+    load = Holidays::Definition::Context::Load.new(merger, File.expand_path(File.dirname(__FILE__)) + '/../data')
+
+    cache_repo.cache_between(Date.civil(2025, 1, 1), Date.civil(2025, 12, 31), [], [:de_be])
+    assert_not_empty cache_repo.instance_variable_get(:@cache_range)
+
+    load.call(:test_region)
+
+    assert_empty cache_repo.instance_variable_get(:@cache_range)
+  end
+
 end

--- a/test/integration/test_cache_invalidation.rb
+++ b/test/integration/test_cache_invalidation.rb
@@ -1,0 +1,26 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../test_helper'
+
+class CacheInvalidationTest < Test::Unit::TestCase
+
+  def test_load_custom_after_cache_between_is_visible_regardless_of_region_argument_shape
+    start_date = Date.civil(2025, 1, 1)
+    end_date = Date.civil(2025, 12, 31)
+    holiday_date = Date.civil(2025, 7, 3)
+
+    # Populate the result cache for de_be before the custom holiday exists.
+    Holidays.cache_between(start_date, end_date, :de_be)
+
+    assert_equal [], Holidays.on(holiday_date, :de_be).select { |h| h[:name] == "Zzz Cache Invalidation Test Day" }
+
+    Holidays.load_custom('test/integration/data/test_cache_invalidation_defs.yaml')
+
+    symbol_names = Holidays.on(holiday_date, :de_be).map { |h| h[:name] }
+    array_names = Holidays.on(holiday_date, [:de_be]).map { |h| h[:name] }
+    unscoped_names = Holidays.on(holiday_date).map { |h| h[:name] }
+
+    assert_include symbol_names, "Zzz Cache Invalidation Test Day"
+    assert_include array_names, "Zzz Cache Invalidation Test Day"
+    assert_include unscoped_names, "Zzz Cache Invalidation Test Day"
+  end
+
+end


### PR DESCRIPTION
Fixes #437.

Holidays.cache_between stores computed results keyed by region options, but nothing invalidated that cache when new definitions were merged afterwards (load_custom, or a lazy region load triggered by querying an unloaded region). A cache warmed before a merge kept serving pre-merge answers, so newly loaded holidays could be invisible to queries that fell inside the cached range.

The original report showed this as a symbol vs. array asymmetry in the region argument, but that half was already fixed by 49b815a (cache key normalization). The stale-cache defect itself was still present on master and affected both argument forms equally.

Fix: Definition::Context::Merger is the single choke point for every definition merge (load_custom and lazy region loads both go through it via Factory::Definition.merger), so it now resets both the result cache and the proc result cache after a successful merge, and also when a repo raises mid-merge.